### PR TITLE
021-A: Make pytest import kanyo without manual PYTHONPATH or cv2

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 testpaths = tests
+pythonpath = src
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*

--- a/src/kanyo/detection/__init__.py
+++ b/src/kanyo/detection/__init__.py
@@ -6,11 +6,19 @@ Modules:
     events: Event models and persistence (FalconVisit, EventStore)
     capture: Video capture utilities
     buffer_monitor: Live stream monitoring with buffer-based clip extraction
+
+Heavy submodules (capture, detect) import cv2/ultralytics and are loaded
+lazily so that lightweight consumers (e.g. tests of events/config) can
+import this package without OpenCV installed.
 """
 
-from kanyo.detection.capture import Frame, StreamCapture
-from kanyo.detection.detect import Detection, FalconDetector
-from kanyo.detection.events import EventStore, EventRecord, FalconVisit
+from typing import TYPE_CHECKING, Any
+
+from kanyo.detection.events import EventRecord, EventStore, FalconVisit
+
+if TYPE_CHECKING:
+    from kanyo.detection.capture import Frame, StreamCapture
+    from kanyo.detection.detect import Detection, FalconDetector
 
 __all__ = [
     "StreamCapture",
@@ -21,3 +29,23 @@ __all__ = [
     "FalconVisit",
     "EventStore",
 ]
+
+_LAZY_ATTRS = {
+    "StreamCapture": ("kanyo.detection.capture", "StreamCapture"),
+    "Frame": ("kanyo.detection.capture", "Frame"),
+    "FalconDetector": ("kanyo.detection.detect", "FalconDetector"),
+    "Detection": ("kanyo.detection.detect", "Detection"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    target = _LAZY_ATTRS.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module_name, attr_name = target
+    from importlib import import_module
+
+    module = import_module(module_name)
+    value = getattr(module, attr_name)
+    globals()[name] = value
+    return value


### PR DESCRIPTION
## Summary

First task in the [021 code-stabilization series](../blob/main/devlog/Agent-Tasks/021-code-stabilization.md). Foundation: every other 021-* task assumes `pytest` runs cleanly from a fresh checkout.

- `pytest.ini`: add `pythonpath = src` so `pytest` from repo root finds the `kanyo` package without `PYTHONPATH=src` prefix.
- `src/kanyo/detection/__init__.py`: lazy-import `capture` and `detect` (which pull `cv2` / `ultralytics`) via PEP 562 `__getattr__`. Lightweight consumers (`kanyo.detection.events`, `kanyo.utils.config`, logger, etc.) can now be imported without OpenCV installed. Public API unchanged.

## Acceptance

| Check | Status |
|---|---|
| `pytest tests/test_events.py tests/test_logger.py tests/test_config_validation.py` passes with no `PYTHONPATH` | ✅ 29/29 pass |
| `import kanyo.detection.events` does NOT pull `capture` or `detect` into `sys.modules` | ✅ verified |
| `from kanyo.detection import StreamCapture` (lazy access) still resolves | ✅ verified |
| `pytest --collect-only` succeeds (262 tests collected, no `ModuleNotFoundError`) | ✅ |
| `mypy src/kanyo/detection/__init__.py` | ✅ no issues |
| `black --check` / `flake8` on touched file | ✅ clean |
| Full `pytest` baseline | 258 pass / 4 pre-existing failures unrelated to this change |

The 4 pre-existing failures (1 `test_detection`, 3 `test_log_service`) exist on `main` and are out of scope for this task.

## Test plan

- [ ] Confirm `pytest` (no args, no env vars) collects all tests without error
- [ ] Confirm the lightweight subset passes
- [ ] Confirm `from kanyo.detection import StreamCapture` still works in any code that does it

## Related

- Parent: `devlog/Agent-Tasks/021-code-stabilization.md`
- Spec: `devlog/Agent-Tasks/021-A-test-import-infrastructure.md`