### PR TITLE
021-B: Fix admin restart/stop/start TypeError on get_latest_thumbnail

### DIFF
--- a/admin/web/app/routers/api.py
+++ b/admin/web/app/routers/api.py
@@ -53,6 +53,18 @@ async def get_stream(stream_id: str):
     return stream
 
 
+def _refresh_stream_card(stream: dict) -> None:
+    """Populate stream dict with current status + clip info for the card fragment."""
+    status = docker_service.get_container_status(stream["container_name"])
+    stream["status"] = status["status"]
+    stream["uptime"] = status.get("uptime", "")
+    stream["latest_thumbnail"] = clip_service.get_latest_thumbnail(
+        stream["clips_path"], stream["id"]
+    )
+    stream["today_visits"] = clip_service.get_today_visits(stream["clips_path"])
+    stream["last_event"] = clip_service.get_last_event(stream["clips_path"])
+
+
 @router.post("/streams/{stream_id}/restart")
 async def restart_stream(stream_id: str):
     """Restart container and return HTML fragment."""
@@ -65,18 +77,7 @@ async def restart_stream(stream_id: str):
     if not success:
         raise HTTPException(status_code=500, detail="Failed to restart container")
 
-    # Return updated stream card HTML fragment
-    from app.services import clip_service
-
-    # Get updated status
-    status = docker_service.get_container_status(stream["container_name"])
-    stream["status"] = status["status"]
-    stream["uptime"] = status.get("uptime", "")
-
-    # Get clip info
-    stream["latest_thumbnail"] = clip_service.get_latest_thumbnail(stream["clips_path"])
-    stream["today_visits"] = clip_service.get_today_visits(stream["clips_path"])
-    stream["last_event"] = clip_service.get_last_event(stream["clips_path"])
+    _refresh_stream_card(stream)
 
     return templates.TemplateResponse(
         "components/stream_card.html", {"request": {}, "stream": stream}, media_type="text/html"
@@ -95,18 +96,7 @@ async def stop_stream(stream_id: str):
     if not success:
         raise HTTPException(status_code=500, detail="Failed to stop container")
 
-    # Return updated stream card HTML fragment
-    from app.services import clip_service
-
-    # Get updated status
-    status = docker_service.get_container_status(stream["container_name"])
-    stream["status"] = status["status"]
-    stream["uptime"] = status.get("uptime", "")
-
-    # Get clip info
-    stream["latest_thumbnail"] = clip_service.get_latest_thumbnail(stream["clips_path"])
-    stream["today_visits"] = clip_service.get_today_visits(stream["clips_path"])
-    stream["last_event"] = clip_service.get_last_event(stream["clips_path"])
+    _refresh_stream_card(stream)
 
     return templates.TemplateResponse(
         "components/stream_card.html", {"request": {}, "stream": stream}, media_type="text/html"
@@ -125,18 +115,7 @@ async def start_stream(stream_id: str):
     if not success:
         raise HTTPException(status_code=500, detail="Failed to start container")
 
-    # Return updated stream card HTML fragment
-    from app.services import clip_service
-
-    # Get updated status
-    status = docker_service.get_container_status(stream["container_name"])
-    stream["status"] = status["status"]
-    stream["uptime"] = status.get("uptime", "")
-
-    # Get clip info
-    stream["latest_thumbnail"] = clip_service.get_latest_thumbnail(stream["clips_path"])
-    stream["today_visits"] = clip_service.get_today_visits(stream["clips_path"])
-    stream["last_event"] = clip_service.get_last_event(stream["clips_path"])
+    _refresh_stream_card(stream)
 
     return templates.TemplateResponse(
         "components/stream_card.html", {"request": {}, "stream": stream}, media_type="text/html"


### PR DESCRIPTION
## Summary

Second task in the [021 code-stabilization series](../blob/main/devlog/Agent-Tasks/021-code-stabilization.md).

- `clip_service.get_latest_thumbnail()` requires `(clips_path, stream_id)` but restart/stop/start handlers all called it with one argument, raising `TypeError` on every action.
- Extracted `_refresh_stream_card(stream)` helper for the identical 6-line "refresh card" block — three handlers now share one implementation.
- Helper passes the missing `stream["id"]` argument.

## Diff stats

| Before | After |
|---|---|
| 51 lines of duplicated refresh logic across 3 handlers | 15-line helper + 3 one-line calls |

## No regression test (intentional)

`admin/web` is deployed as a separate container with its own deps; `fastapi` is not in `requirements-dev.txt`. Adding it just for one router test was deferred. Verification is by PR diff inspection.

Manual verification steps to run on the admin container after merge:
- [ ] Click restart on a running stream → card refreshes, no 500 error in logs
- [ ] Click stop on a running stream → card shows stopped status
- [ ] Click start on a stopped stream → card shows starting/running status
- [ ] In all three cases, the thumbnail in the refreshed card is for the correct stream

## Related

- Parent: `devlog/Agent-Tasks/021-code-stabilization.md`
- Spec: `devlog/Agent-Tasks/021-B-admin-thumbnail-crash.md`