### PR TITLE
021-K: Add EventMetadata/StateEvent type aliases; mypy now clean

### DIFF
--- a/src/kanyo/detection/falcon_state.py
+++ b/src/kanyo/detection/falcon_state.py
@@ -8,12 +8,16 @@ Roosting is mainly for notifications - both states use the same exit timeout.
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Any
 
 from kanyo.utils.logger import get_logger
 
 from .event_types import FalconEvent, FalconState
 
 logger = get_logger(__name__)
+
+EventMetadata = dict[str, Any]
+StateEvent = tuple[FalconEvent, datetime, EventMetadata]
 
 
 class FalconStateMachine:
@@ -65,9 +69,7 @@ class FalconStateMachine:
         self.pre_outage_state: FalconState | None = None
         self.pre_outage_roosting_start: datetime | None = None
 
-    def update(
-        self, falcon_detected: bool, timestamp: datetime
-    ) -> list[tuple[FalconEvent, datetime, dict]]:
+    def update(self, falcon_detected: bool, timestamp: datetime) -> list[StateEvent]:
         """
         Update state based on detection status.
 
@@ -78,7 +80,7 @@ class FalconStateMachine:
         Returns:
             List of (event_type, event_timestamp, metadata) tuples for events that occurred
         """
-        events = []
+        events: list[StateEvent] = []
 
         if falcon_detected:
             events.extend(self._handle_detection(timestamp))
@@ -104,9 +106,9 @@ class FalconStateMachine:
             FalconState.PENDING_RECOVERY,
         )
 
-    def _handle_detection(self, timestamp: datetime) -> list[tuple[FalconEvent, datetime, dict]]:
+    def _handle_detection(self, timestamp: datetime) -> list[StateEvent]:
         """Handle falcon detection based on current state."""
-        events = []
+        events: list[StateEvent] = []
 
         if self.state == FalconState.ABSENT:
             # ABSENT → VISITING: Falcon arrived
@@ -144,7 +146,7 @@ class FalconStateMachine:
                     self.state = FalconState.ROOSTING
                     self.roosting_start = timestamp
 
-                    metadata: dict[str, datetime | float | None] = {
+                    metadata: EventMetadata = {
                         "visit_start": self.visit_start,
                         "visit_duration_seconds": visit_duration,
                         "roosting_start": timestamp,
@@ -168,9 +170,9 @@ class FalconStateMachine:
 
         return events
 
-    def _handle_absence(self, timestamp: datetime) -> list[tuple[FalconEvent, datetime, dict]]:
+    def _handle_absence(self, timestamp: datetime) -> list[StateEvent]:
         """Handle falcon absence based on current state."""
-        events = []
+        events: list[StateEvent] = []
 
         # Track absence start
         if self.last_absence_start is None and self.last_detection is not None:
@@ -358,7 +360,7 @@ class FalconStateMachine:
         self.pre_outage_roosting_start = None
         logger.info(f"✅ RECOVERY CONFIRMED - falcon still present, resuming {self.state.value}")
 
-    def cancel_recovery(self, timestamp: datetime) -> list[tuple[FalconEvent, datetime, dict]]:
+    def cancel_recovery(self, timestamp: datetime) -> list[StateEvent]:
         """
         Cancel recovery - falcon left during the stream outage.
 
@@ -373,6 +375,10 @@ class FalconStateMachine:
         if self.state != FalconState.PENDING_RECOVERY:
             logger.warning(f"cancel_recovery called in {self.state} state, ignoring")
             return []
+
+        # Invariant: entering PENDING_RECOVERY only happens from VISITING/ROOSTING,
+        # both of which require last_detection to have been set.
+        assert self.last_detection is not None, "PENDING_RECOVERY entered without last_detection"
 
         # Generate departure event with last_detection (from before outage)
         total_duration = (


### PR DESCRIPTION
## Summary

Final task in the first 021-* batch. Type cleanup only — no behavior change.

- Added module-level aliases in `src/kanyo/detection/falcon_state.py`:
  ```python
  EventMetadata = dict[str, Any]
  StateEvent = tuple[FalconEvent, datetime, EventMetadata]
  ```
- Applied to `update()`, `_handle_detection()`, `_handle_absence()`, `cancel_recovery()` return types and to the local `events: list[StateEvent]` annotations.
- In `cancel_recovery()`, added `assert self.last_detection is not None` after the PENDING_RECOVERY guard. The invariant: `PENDING_RECOVERY` is only entered from `VISITING`/`ROOSTING`, both of which set `last_detection`. The assert documents the invariant and eliminates the mypy error on the return tuple's timestamp slot.

## Verification

| Check | Before | After |
|---|---|---|
| `mypy src/kanyo` errors in `falcon_state.py` | 2 | **0** |
| `pytest tests/test_falcon_state.py` | 31 passed | 31 passed |
| `pytest` full suite | 258 passed, 4 pre-existing failures | 258 passed, 4 pre-existing failures (unchanged) |
| `black --check` on touched file | clean | clean |

The 1 remaining mypy error in the `src/kanyo` tree is `kanyo/utils/notifications.py` missing `types-requests` stubs — pre-existing and unrelated.

## Test plan

- [x] `mypy src/kanyo` — only the pre-existing `types-requests` warning remains
- [x] Existing `test_falcon_state.py` suite passes unchanged
- [x] No runtime behavior change

## Related

- Parent: `devlog/Agent-Tasks/021-code-stabilization.md`
- Spec: `devlog/Agent-Tasks/021-K-mypy-event-tuple-types.md`