### PR TITLE
ci: fix build-cpu tag template producing invalid ":-<sha>" on PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=cpu,enable={{is_default_branch}}
-            type=sha,prefix={{branch}}-
+            type=sha,prefix=cpu-
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5


### PR DESCRIPTION
## Problem

Every PR's `build-cpu` job has been failing with:

```
ERROR: failed to build: invalid tag "ghcr.io/sageframe-no-kaji/kanyo-contemplating-falcons-dev:-eb595f9": invalid reference format
```

Note the malformed `:-<sha>` — the colon is followed immediately by a dash.

## Cause

`.github/workflows/build.yml` build-cpu metadata config had:

```yaml
type=sha,prefix={{branch}}-
```

On `pull_request` events the `{{branch}}` template resolves to an empty string (PRs have no single branch context that the metadata-action can fill that template from), so the prefix becomes just `-`, producing `:-<sha>`.

`build-nvidia` uses `prefix=nvidia-` (static string) and passes cleanly.

## Fix

Use the same static-prefix pattern for cpu:

```yaml
type=sha,prefix=cpu-
```

Symmetric with nvidia, no template-context dependency, works on push AND pull_request.

## Impact

Unblocks every open and future 021-* PR. Existing PRs (#20, #21, #22) will re-run CI on next push or can be re-run manually via the Actions tab → "Re-run failed jobs."

This is a 1-line workflow fix, not part of the 021 stabilization series proper.