### PR TITLE
021-C: Unify stream data root between create_stream() and compose mount

### DIFF
--- a/admin/web/app/services/stream_manager.py
+++ b/admin/web/app/services/stream_manager.py
@@ -1,5 +1,6 @@
 """Stream creation and management."""
 
+import os
 import re
 import subprocess
 
@@ -49,6 +50,21 @@ SERVICES_BASE = Path("/opt/services")
 ADMIN_COMPOSE = Path("/opt/services/kanyo-admin/docker-compose.yml")
 
 
+def stream_root_for(stream_id: str) -> Path:
+    """Canonical filesystem root for a stream's config/clips/logs.
+
+    Mirrors the compose volume default (`./data/{id}`, resolved relative
+    to ADMIN_COMPOSE.parent) so create_stream() writes files at the same
+    path the detection container mounts. The KANYO_{STREAM}_ROOT env var
+    overrides both — compose reads it as a volume default; this function
+    reads the same name so file creation and mount stay in sync.
+    """
+    override = os.environ.get(f"KANYO_{stream_id.upper()}_ROOT")
+    if override:
+        return Path(override)
+    return ADMIN_COMPOSE.parent / "data" / stream_id
+
+
 def validate_stream_id(stream_id: str) -> tuple[bool, str]:
     """Validate stream ID format."""
     if not stream_id:
@@ -84,7 +100,7 @@ def create_stream(
     if not video_source.startswith("http"):
         return False, "Video source must be a valid URL"
 
-    stream_dir = SERVICES_BASE / f"kanyo-{stream_id}"
+    stream_dir = stream_root_for(stream_id)
 
     # Check if already exists
     if stream_dir.exists():


### PR DESCRIPTION
## Summary

Third task in the [021 stabilization series](../blob/main/devlog/Agent-Tasks/021-code-stabilization.md). Fixes a real bug where new streams created via the admin UI never saw their own config files.

## Before

| Side | Path |
|---|---|
| `create_stream()` writes to | `/opt/services/kanyo-{id}/` |
| Compose default mounts | `./data/{id}` → `/opt/services/kanyo-admin/data/{id}/` |

Two completely different directories. Unless the operator set `KANYO_{STREAM}_ROOT` env var (rare), the on-disk files were orphaned and the container started with no config.

## After

Single canonical builder:

```python
def stream_root_for(stream_id: str) -> Path:
    override = os.environ.get(f"KANYO_{stream_id.upper()}_ROOT")
    if override:
        return Path(override)
    return ADMIN_COMPOSE.parent / "data" / stream_id
```

Returns exactly the path compose mounts. `create_stream()` now uses it; `_cleanup(stream_dir)` on rollback still deletes the same directory.

`KANYO_{STREAM}_ROOT` still overrides — and now overrides BOTH file creation and compose mount via the same env var name, so they cannot diverge.

## What did NOT change

- `SERVICES_BASE`, `ADMIN_COMPOSE` constants — kept for backward compat / orphan-detection in `get_available_streams()`.
- `_add_admin_volume` / `_add_to_detection_compose` — the compose-file generation already used `./data/{id}` default; now correct because `stream_root_for()` matches.
- Existing streams under `/opt/services/kanyo-{id}/` are not migrated; this fix only changes NEW stream creation.

## Verification (manual)

`admin/web` has no test infra in this repo (no `fastapi` in `requirements-dev.txt`). Manual verification on the admin container after merge:

- [ ] Create a new stream via admin UI → confirm files appear at `/opt/services/kanyo-admin/data/{id}/` (config.yaml, clips/, logs/)
- [ ] Confirm container starts and `docker exec <container> cat /app/config.yaml` returns the file content
- [ ] Force-fail compose update mid-create (e.g. temporarily move compose file) → confirm `_cleanup` removes the created dir
- [ ] Set `KANYO_TESTNEST_ROOT=/some/other/path` in admin container env → create stream `testnest` → confirm files go to `/some/other/path/` and container mounts it

## Related

- Parent: `devlog/Agent-Tasks/021-code-stabilization.md`
- Spec: `devlog/Agent-Tasks/021-C-stream-creation-path-mismatch.md`