### PR TITLE
021-G: Admin timezone handling — mapped offsets + stream-tz-aware last event

### DIFF
--- a/admin/web/app/routers/api.py
+++ b/admin/web/app/routers/api.py
@@ -76,7 +76,9 @@ async def restart_stream(stream_id: str):
     # Get clip info
     stream["latest_thumbnail"] = clip_service.get_latest_thumbnail(stream["clips_path"])
     stream["today_visits"] = clip_service.get_today_visits(stream["clips_path"])
-    stream["last_event"] = clip_service.get_last_event(stream["clips_path"])
+    stream["last_event"] = clip_service.get_last_event(
+        stream["clips_path"], stream.get("timezone", "UTC")
+    )
 
     return templates.TemplateResponse(
         "components/stream_card.html", {"request": {}, "stream": stream}, media_type="text/html"
@@ -106,7 +108,9 @@ async def stop_stream(stream_id: str):
     # Get clip info
     stream["latest_thumbnail"] = clip_service.get_latest_thumbnail(stream["clips_path"])
     stream["today_visits"] = clip_service.get_today_visits(stream["clips_path"])
-    stream["last_event"] = clip_service.get_last_event(stream["clips_path"])
+    stream["last_event"] = clip_service.get_last_event(
+        stream["clips_path"], stream.get("timezone", "UTC")
+    )
 
     return templates.TemplateResponse(
         "components/stream_card.html", {"request": {}, "stream": stream}, media_type="text/html"
@@ -136,7 +140,9 @@ async def start_stream(stream_id: str):
     # Get clip info
     stream["latest_thumbnail"] = clip_service.get_latest_thumbnail(stream["clips_path"])
     stream["today_visits"] = clip_service.get_today_visits(stream["clips_path"])
-    stream["last_event"] = clip_service.get_last_event(stream["clips_path"])
+    stream["last_event"] = clip_service.get_last_event(
+        stream["clips_path"], stream.get("timezone", "UTC")
+    )
 
     return templates.TemplateResponse(
         "components/stream_card.html", {"request": {}, "stream": stream}, media_type="text/html"

--- a/admin/web/app/routers/pages.py
+++ b/admin/web/app/routers/pages.py
@@ -33,7 +33,9 @@ async def overview(request: Request):
             stream["clips_path"], stream["id"]
         )
         stream["today_visits"] = clip_service.get_today_visits(stream["clips_path"])
-        stream["last_event"] = clip_service.get_last_event(stream["clips_path"])
+        stream["last_event"] = clip_service.get_last_event(
+            stream["clips_path"], stream.get("timezone", "UTC")
+        )
 
     # Get hostname
     hostname = socket.gethostname()

--- a/admin/web/app/services/clip_service.py
+++ b/admin/web/app/services/clip_service.py
@@ -1,32 +1,73 @@
 """Clip browsing and management service."""
 
 from pathlib import Path
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone, tzinfo
 from typing import Optional
 from zoneinfo import ZoneInfo
 import re
 from PIL import Image, ImageDraw
 
+# DUPLICATE — keep in sync with src/kanyo/utils/config.py OFFSET_TO_TZ.
+# Admin container doesn't import kanyo, so the mapping is copied here.
+# See 021-G.
+OFFSET_TO_TZ = {
+    "+11:00": "Australia/Sydney",
+    "+10:00": "Australia/Brisbane",
+    "+09:30": "Australia/Adelaide",
+    "+08:00": "Asia/Singapore",
+    "-05:00": "America/New_York",
+    "-06:00": "America/Chicago",
+    "-07:00": "America/Denver",
+    "-08:00": "America/Los_Angeles",
+    "-10:00": "Pacific/Honolulu",
+    "+00:00": "UTC",
+}
 
-def get_stream_timezone(stream_timezone: str) -> ZoneInfo:
+
+def get_stream_timezone(stream_timezone: str) -> tzinfo:
     """
-    Parse stream timezone string to ZoneInfo object.
+    Parse stream timezone string to a tzinfo object.
+
+    Supports:
+    - IANA names: "Australia/Sydney", "America/New_York"
+    - Mapped offsets via OFFSET_TO_TZ: "+11:00" → Australia/Sydney
+    - Unmapped ±HH:MM offsets: returns a fixed-offset timezone (not UTC)
+    - Invalid: returns UTC with no exception
 
     Args:
-        stream_timezone: IANA timezone name (e.g., "Australia/Sydney") or offset (e.g., "+11:00")
+        stream_timezone: timezone string from stream config
 
     Returns:
-        ZoneInfo object for the stream's timezone
+        tzinfo (ZoneInfo for IANA / mapped, datetime.timezone for raw offsets)
     """
-    # Handle IANA timezone names
-    if "/" in stream_timezone or stream_timezone in ("UTC", "GMT"):
+    if not stream_timezone or stream_timezone in ("UTC", "GMT", "+00:00"):
+        return ZoneInfo("UTC")
+
+    # IANA name
+    if "/" in stream_timezone:
         try:
             return ZoneInfo(stream_timezone)
         except Exception:
             return ZoneInfo("UTC")
 
-    # Handle offset format (legacy) - just use UTC for admin
-    # The detection system will handle proper offset parsing
+    # Mapped legacy offset → real IANA zone (DST-aware)
+    if stream_timezone in OFFSET_TO_TZ:
+        try:
+            return ZoneInfo(OFFSET_TO_TZ[stream_timezone])
+        except Exception:
+            return ZoneInfo("UTC")
+
+    # Unmapped ±HH:MM offset → fixed-offset tzinfo (NOT UTC)
+    if stream_timezone.startswith(("+", "-")):
+        try:
+            sign = 1 if stream_timezone[0] == "+" else -1
+            parts = stream_timezone[1:].split(":")
+            hours = int(parts[0])
+            minutes = int(parts[1]) if len(parts) > 1 else 0
+            return timezone(timedelta(hours=sign * hours, minutes=sign * minutes))
+        except Exception:
+            return ZoneInfo("UTC")
+
     return ZoneInfo("UTC")
 
 
@@ -380,53 +421,76 @@ def get_today_visits(clips_path: str) -> int:
     return sum(1 for clip in clips if clip["type"] == "arrival")
 
 
-def get_last_event(clips_path: str) -> Optional[dict]:
+def get_last_event(clips_path: str, stream_timezone: str = "UTC") -> Optional[dict]:
     """
-    Get most recent event.
+    Get the most recent event in the stream's timezone.
+
+    Uses date folders and parsed filename timestamps, NOT file mtime — so
+    a stream in +11:00 displays an event time correctly even when the
+    server is in UTC. See 021-G.
 
     Args:
         clips_path: Path to clips directory
+        stream_timezone: Stream's timezone (IANA name or legacy offset)
 
     Returns:
-        Dict with time, type, ago or None
+        Dict with time, type, date, ago — or None if no events found.
     """
     clips_dir = Path(clips_path)
     if not clips_dir.exists():
         return None
 
-    latest_file = None
-    latest_time = 0
+    tz = get_stream_timezone(stream_timezone)
+    now_local = datetime.now(tz)
+
+    # Pattern: falcon_HHMMSS_type.ext (mp4/jpg/etc.). Skip .tmp and .log.
+    pattern = re.compile(
+        r"falcon_(\d{6})_(\w+)\.(mp4|jpg|jpeg|avi|mov|mkv|png)$",
+        re.IGNORECASE,
+    )
+
+    latest_dt: Optional[datetime] = None
     latest_type = ""
 
-    # Search recent date folders (last 7 days)
+    # Walk the last 7 date folders in stream-local time
     for i in range(7):
-        date = (datetime.now() - timedelta(days=i)).strftime("%Y-%m-%d")
-        date_path = clips_dir / date
-
+        date_str = (now_local - timedelta(days=i)).strftime("%Y-%m-%d")
+        date_path = clips_dir / date_str
         if not date_path.exists():
             continue
 
-        # Pattern: falcon_HHMMSS_type.ext
-        pattern = re.compile(r"falcon_(\d{6})_(\w+)\.(\w+)$")
+        try:
+            date_part = datetime.strptime(date_str, "%Y-%m-%d")
+        except ValueError:
+            continue
 
         for file in date_path.iterdir():
+            if not file.is_file():
+                continue
             match = pattern.match(file.name)
             if not match:
                 continue
+            time_str, ev_type, _ext = match.groups()
+            try:
+                clip_dt = date_part.replace(
+                    hour=int(time_str[:2]),
+                    minute=int(time_str[2:4]),
+                    second=int(time_str[4:6]),
+                    tzinfo=tz,
+                )
+            except (ValueError, OverflowError):
+                continue
+            # Skip "future" files (clock skew, bad filenames)
+            if clip_dt > now_local:
+                continue
+            if latest_dt is None or clip_dt > latest_dt:
+                latest_dt = clip_dt
+                latest_type = ev_type
 
-            mtime = file.stat().st_mtime
-            if mtime > latest_time:
-                latest_time = mtime
-                latest_type = match.group(2)
-                latest_file = file
-
-    if not latest_file:
+    if latest_dt is None:
         return None
 
-    # Calculate time ago
-    now = datetime.now().timestamp()
-    delta_seconds = int(now - latest_time)
-
+    delta_seconds = int((now_local - latest_dt).total_seconds())
     if delta_seconds < 60:
         ago = f"{delta_seconds}s ago"
     elif delta_seconds < 3600:
@@ -437,8 +501,9 @@ def get_last_event(clips_path: str) -> Optional[dict]:
         ago = f"{delta_seconds // 86400}d ago"
 
     return {
-        "time": datetime.fromtimestamp(latest_time).strftime("%H:%M:%S"),
+        "time": latest_dt.strftime("%H:%M:%S"),
         "type": latest_type,
+        "date": latest_dt.strftime("%Y-%m-%d"),
         "ago": ago,
     }
 

--- a/src/kanyo/utils/config.py
+++ b/src/kanyo/utils/config.py
@@ -179,6 +179,11 @@ def _parse_timezone(tz_str: str) -> ZoneInfo | timezone:
     return timezone.utc
 
 
+# Public alias — kept stable so external consumers (admin web service,
+# downstream tooling) can rely on the name. See 021-G.
+parse_stream_timezone = _parse_timezone
+
+
 def get_now_tz(config: dict[str, Any]) -> datetime:
     """Get current time in the configured timezone."""
     tz_obj = config.get("timezone_obj", timezone.utc)

--- a/tests/test_parse_stream_timezone_021g.py
+++ b/tests/test_parse_stream_timezone_021g.py
@@ -1,0 +1,75 @@
+"""Regression tests for 021-G: parse_stream_timezone is the public shared name
+that admin web service and any other consumer can reuse.
+
+Core parses correctly for IANA names, mapped legacy offsets (+11:00 etc.),
+unmapped offsets (returns fixed-offset tzinfo, not UTC), and invalid input
+(falls back to UTC without raising).
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from zoneinfo import ZoneInfo
+
+from kanyo.utils.config import OFFSET_TO_TZ, parse_stream_timezone
+
+
+class TestParseStreamTimezone:
+    def test_iana_name_resolves_to_zoneinfo(self):
+        tz = parse_stream_timezone("America/New_York")
+        assert isinstance(tz, ZoneInfo)
+        assert tz.key == "America/New_York"
+
+    def test_utc_string(self):
+        tz = parse_stream_timezone("UTC")
+        assert isinstance(tz, ZoneInfo)
+        assert tz.key == "UTC"
+
+    def test_plus_zero_normalised_to_utc(self):
+        tz = parse_stream_timezone("+00:00")
+        assert isinstance(tz, ZoneInfo)
+        assert tz.key == "UTC"
+
+    def test_mapped_legacy_offset_plus_11(self):
+        """+11:00 maps to Australia/Sydney via OFFSET_TO_TZ."""
+        tz = parse_stream_timezone("+11:00")
+        assert isinstance(tz, ZoneInfo)
+        assert tz.key == "Australia/Sydney"
+
+    def test_mapped_legacy_offset_minus_5(self):
+        tz = parse_stream_timezone("-05:00")
+        assert isinstance(tz, ZoneInfo)
+        assert tz.key == "America/New_York"
+
+    def test_unmapped_offset_returns_fixed_offset_not_utc(self):
+        """Unmapped offsets must NOT silently become UTC — they get a real
+        fixed-offset tzinfo so timestamps render correctly."""
+        # +04:00 is not in OFFSET_TO_TZ
+        tz = parse_stream_timezone("+04:00")
+        # Should be a datetime.timezone, not UTC
+        assert isinstance(tz, timezone)
+        now = datetime.now(tz)
+        assert now.utcoffset() == timedelta(hours=4)
+
+    def test_invalid_string_falls_back_to_utc_no_raise(self):
+        tz = parse_stream_timezone("not-a-timezone")
+        # Either ZoneInfo("UTC") or timezone.utc — both are valid fallbacks
+        assert datetime.now(tz).utcoffset() == timedelta(0)
+
+    def test_empty_string_returns_utc(self):
+        tz = parse_stream_timezone("")
+        assert datetime.now(tz).utcoffset() == timedelta(0)
+
+
+class TestOffsetToTzMapShape:
+    """Pin the shape of OFFSET_TO_TZ so admin's DUPLICATE copy stays consistent."""
+
+    def test_known_offsets_present(self):
+        # If any of these go missing, the admin DUPLICATE map is also out of date.
+        for offset in ["+11:00", "-05:00", "-08:00", "+00:00"]:
+            assert offset in OFFSET_TO_TZ, (
+                f"{offset} missing from core OFFSET_TO_TZ — also remove from admin's"
+            )
+
+    def test_values_are_resolvable_iana(self):
+        for offset, name in OFFSET_TO_TZ.items():
+            ZoneInfo(name)  # raises if invalid; this is the assertion


### PR DESCRIPTION
## Summary

Two bugs sharing one root cause: admin's `clip_service` was UTC-naive whenever the stream's timezone was anything but an IANA name (e.g. `+11:00`, `-05:00`). Result: wrong "today", wrong "last event" time, wrong "ago" — pretty much every timestamp shown in admin for non-IANA streams was off.

## Fix 1 — `get_stream_timezone` now handles legacy offsets

| Input | Before | After |
|---|---|---|
| `Australia/Sydney` | ZoneInfo (correct) | ZoneInfo (same) |
| `+11:00` | **UTC (wrong)** | `Australia/Sydney` via OFFSET_TO_TZ |
| `-05:00` | **UTC (wrong)** | `America/New_York` |
| `+04:00` (unmapped) | **UTC (wrong)** | `datetime.timezone(+04:00)` — fixed-offset, not UTC |
| invalid / empty | UTC | UTC (unchanged) |

Map is copied into `admin/web/app/services/clip_service.py` with a `# DUPLICATE — keep in sync with src/kanyo/utils/config.py OFFSET_TO_TZ` comment. Admin/web container does NOT import kanyo, so the duplication is necessary.

## Fix 2 — `get_last_event` is stream-tz aware

Before: walked date folders by `datetime.now()` (server-local), ranked by file `mtime`, formatted with `datetime.fromtimestamp()` (also server-local). A stream in `+11:00` viewed from a UTC server displayed wrong everything.

After:
- Accepts `stream_timezone` parameter (defaulting to UTC for back-compat).
- Walks the last 7 date folders in **stream-local** time.
- Parses `HHMMSS` from filename and constructs a stream-tz-aware datetime.
- Computes "ago" against `datetime.now(stream_tz)`.
- Returned dict now also includes `"date"` so callers can render `<date> <time>` without recomputing.

All 4 callers updated:
- `admin/web/app/routers/api.py` × 3 (restart, stop, start handlers)
- `admin/web/app/routers/pages.py` × 1 (overview page loop)

Each passes `stream.get("timezone", "UTC")`.

## Core helper promoted

`kanyo.utils.config._parse_timezone` is now also exposed as `parse_stream_timezone` (a stable alias). Downstream tooling — including future shared utilities — can rely on the public name.

## Tests

`tests/test_parse_stream_timezone_021g.py` — 10 cases:

- IANA name, `UTC`, `+00:00`
- mapped legacy offsets (`+11:00`, `-05:00`)
- unmapped offset → fixed-offset tzinfo (NOT UTC)
- invalid input falls back to UTC without raising
- empty input → UTC
- OFFSET_TO_TZ map shape pinned (presence of key offsets, IANA names resolve)

No admin-side automated tests: admin/web has no test infra in this repo (no `fastapi` or `PIL` in `requirements-dev.txt`). Manual verification:

- [ ] Stream configured with `+11:00` shows last-event time matching Sydney clock
- [ ] Stream in `America/New_York` shows correct time after DST transition
- [ ] Stream with unknown offset like `+04:00` shows time at that offset, not UTC
- [ ] Date folder selection near UTC/local day boundary returns the right folder

## Related

- Parent: `devlog/Agent-Tasks/021-code-stabilization.md`
- Spec: `devlog/Agent-Tasks/021-G-admin-timezone-handling.md`