### PR TITLE
021-I: Add microseconds to output filenames; backward-compatible regex

### DIFF
--- a/admin/web/app/services/clip_service.py
+++ b/admin/web/app/services/clip_service.py
@@ -8,6 +8,20 @@ import re
 from PIL import Image, ImageDraw
 
 
+def _find_thumbnail_at_time(date_path: Path, time_str: str, event_type: str) -> Optional[Path]:
+    """Locate a thumbnail file for the given HHMMSS and event type.
+
+    Tries the new format (021-I: includes microseconds:
+    falcon_HHMMSS_FFFFFF_type.jpg) first, then falls back to the legacy
+    format (no microseconds) for older recordings.
+    """
+    new_format = next(date_path.glob(f"falcon_{time_str}_*_{event_type}.jpg"), None)
+    if new_format and new_format.exists():
+        return new_format
+    legacy = date_path / f"falcon_{time_str}_{event_type}.jpg"
+    return legacy if legacy.exists() else None
+
+
 def get_stream_timezone(stream_timezone: str) -> ZoneInfo:
     """
     Parse stream timezone string to ZoneInfo object.
@@ -124,9 +138,12 @@ def list_clips(clips_path: str, date: str) -> list[dict]:
     if not date_path.exists():
         return []
 
-    # Pattern: falcon_HHMMSS_type.ext (only completed media files)
-    # Exclude .tmp (in-progress) and .log files
-    pattern = re.compile(r"falcon_(\d{6})_(\w+)\.(mp4|jpg|jpeg|avi|mov|mkv|png)$")
+    # Pattern: falcon_HHMMSS[_FFFFFF]_type.ext (microseconds optional for
+    # backward compat with older recordings). Excludes .tmp and .log files.
+    pattern = re.compile(
+        r"falcon_(?P<time>\d{6})(?:_(?P<usec>\d{6}))?_(?P<type>[a-z]+)\."
+        r"(?P<ext>mp4|jpg|jpeg|avi|mov|mkv|png)$"
+    )
 
     for clip_file in sorted(date_path.iterdir(), reverse=True):
         if not clip_file.is_file():
@@ -136,7 +153,9 @@ def list_clips(clips_path: str, date: str) -> list[dict]:
         if not match:
             continue
 
-        time_str, clip_type, ext = match.groups()
+        time_str = match.group("time")
+        clip_type = match.group("type")
+        ext = match.group("ext")
 
         # Parse time
         hour = time_str[:2]
@@ -154,7 +173,7 @@ def list_clips(clips_path: str, date: str) -> list[dict]:
 
             # For visit clips, create composite thumbnail from arrival + nearest departure
             if clip_type == "visit" and not thumb_path.exists():
-                arrival_thumb = date_path / f"falcon_{time_str}_arrival.jpg"
+                arrival_thumb = _find_thumbnail_at_time(date_path, time_str, "arrival")
 
                 # Find departure thumbnail - it may be at a later time
                 departure_thumb = None
@@ -164,7 +183,7 @@ def list_clips(clips_path: str, date: str) -> list[dict]:
                         departure_thumb = dep_file
                         break
 
-                if arrival_thumb.exists() and departure_thumb and departure_thumb.exists():
+                if arrival_thumb and departure_thumb and departure_thumb.exists():
                     create_visit_thumbnail(arrival_thumb, departure_thumb, thumb_path)
 
             has_thumbnail = thumb_path.exists()
@@ -217,9 +236,12 @@ def list_clips_since(clips_path: str, stream_timezone: str, hours: int = 24) -> 
         dates_to_check.add(current.strftime("%Y-%m-%d"))
         current += timedelta(days=1)
 
-    # Pattern: falcon_HHMMSS_type.ext (only completed media files)
-    # Exclude .tmp (in-progress) and .log files
-    pattern = re.compile(r"falcon_(\d{6})_(\w+)\.(mp4|jpg|jpeg|avi|mov|mkv|png)$")
+    # Pattern: falcon_HHMMSS[_FFFFFF]_type.ext (microseconds optional for
+    # backward compat with older recordings). Excludes .tmp and .log files.
+    pattern = re.compile(
+        r"falcon_(?P<time>\d{6})(?:_(?P<usec>\d{6}))?_(?P<type>[a-z]+)\."
+        r"(?P<ext>mp4|jpg|jpeg|avi|mov|mkv|png)$"
+    )
 
     for date_str in sorted(dates_to_check):
         date_path = clips_dir / date_str
@@ -234,7 +256,9 @@ def list_clips_since(clips_path: str, stream_timezone: str, hours: int = 24) -> 
             if not match:
                 continue
 
-            time_str, clip_type, ext = match.groups()
+            time_str = match.group("time")
+            clip_type = match.group("type")
+            ext = match.group("ext")
 
             # Parse clip datetime
             hour = int(time_str[:2])
@@ -265,7 +289,7 @@ def list_clips_since(clips_path: str, stream_timezone: str, hours: int = 24) -> 
 
                 # For visit clips, create composite thumbnail
                 if clip_type == "visit" and not thumb_path.exists():
-                    arrival_thumb = date_path / f"falcon_{time_str}_arrival.jpg"
+                    arrival_thumb = _find_thumbnail_at_time(date_path, time_str, "arrival")
 
                     # Find the closest departure after this visit start
                     # Need to find the matching departure, not just any departure after this time
@@ -293,10 +317,10 @@ def list_clips_since(clips_path: str, stream_timezone: str, hours: int = 24) -> 
                                 closest_time_diff = time_diff
                                 departure_thumb = dep_file
 
-                    if arrival_thumb.exists() and departure_thumb and departure_thumb.exists():
+                    if arrival_thumb and departure_thumb and departure_thumb.exists():
                         # Complete visit: create composite thumbnail
                         create_visit_thumbnail(arrival_thumb, departure_thumb, thumb_path)
-                    elif arrival_thumb.exists():
+                    elif arrival_thumb:
                         # In-progress visit: use arrival thumbnail as fallback
                         import shutil
 
@@ -406,8 +430,8 @@ def get_last_event(clips_path: str) -> Optional[dict]:
         if not date_path.exists():
             continue
 
-        # Pattern: falcon_HHMMSS_type.ext
-        pattern = re.compile(r"falcon_(\d{6})_(\w+)\.(\w+)$")
+        # Pattern: falcon_HHMMSS[_FFFFFF]_type.ext (microseconds optional).
+        pattern = re.compile(r"falcon_(?P<time>\d{6})(?:_(?P<usec>\d{6}))?_(?P<type>[a-z]+)\.\w+$")
 
         for file in date_path.iterdir():
             match = pattern.match(file.name)
@@ -417,7 +441,7 @@ def get_last_event(clips_path: str) -> Optional[dict]:
             mtime = file.stat().st_mtime
             if mtime > latest_time:
                 latest_time = mtime
-                latest_type = match.group(2)
+                latest_type = match.group("type")
                 latest_file = file
 
     if not latest_file:

--- a/src/kanyo/utils/output.py
+++ b/src/kanyo/utils/output.py
@@ -18,6 +18,11 @@ def get_output_path(base_dir: str, timestamp: datetime, event_type: str, extensi
     """
     Generate date-organized output path for clips/thumbnails.
 
+    Includes microseconds in the filename so two events of the same type in
+    the same second do not collide (see 021-I). Format:
+
+        falcon_<HHMMSS>_<MICROSECONDS>_<type>.<ext>
+
     Args:
         base_dir: Base directory (e.g., 'clips')
         timestamp: Event timestamp
@@ -25,12 +30,12 @@ def get_output_path(base_dir: str, timestamp: datetime, event_type: str, extensi
         extension: 'mp4' or 'jpg'
 
     Returns:
-        Path like: clips/2025-12-24/falcon_143025_arrival.mp4
+        Path like: clips/2025-12-24/falcon_143025_123456_arrival.mp4
     """
     date_dir = Path(base_dir) / timestamp.strftime("%Y-%m-%d")
     date_dir.mkdir(parents=True, exist_ok=True)
 
-    filename = f"falcon_{timestamp.strftime('%H%M%S')}_{event_type}.{extension}"
+    filename = f"falcon_{timestamp.strftime('%H%M%S_%f')}_{event_type}.{extension}"
     return date_dir / filename
 
 

--- a/tests/test_admin_filename_regex_021i.py
+++ b/tests/test_admin_filename_regex_021i.py
@@ -1,0 +1,71 @@
+"""Regression for 021-I: admin clip_service regex must accept both old and
+new filename formats so existing recordings remain visible after the format
+change.
+
+The admin module itself cannot be imported here (admin/web has no test deps
+in requirements-dev.txt — see prior 021-* decisions), so this test re-uses
+the same regex source by copying it. If clip_service drifts from this
+pattern, the test alongside it should be updated.
+"""
+
+import re
+
+# Mirrors the regex in admin/web/app/services/clip_service.py (list_clips +
+# list_clips_since). Microseconds slot optional for backward compatibility.
+ADMIN_CLIP_PATTERN = re.compile(
+    r"falcon_(?P<time>\d{6})(?:_(?P<usec>\d{6}))?_(?P<type>[a-z]+)\."
+    r"(?P<ext>mp4|jpg|jpeg|avi|mov|mkv|png)$"
+)
+
+
+class TestRegexAcceptsNewFormat:
+    def test_new_format_with_microseconds(self):
+        m = ADMIN_CLIP_PATTERN.match("falcon_143025_123456_arrival.mp4")
+        assert m is not None
+        assert m.group("time") == "143025"
+        assert m.group("usec") == "123456"
+        assert m.group("type") == "arrival"
+        assert m.group("ext") == "mp4"
+
+    def test_new_format_departure_jpg(self):
+        m = ADMIN_CLIP_PATTERN.match("falcon_080000_000042_departure.jpg")
+        assert m is not None
+        assert m.group("type") == "departure"
+        assert m.group("usec") == "000042"
+
+
+class TestRegexBackwardCompatibleWithOldFormat:
+    """Existing recordings on disk pre-021-I have no microsecond slot.
+    They must still be parsed correctly."""
+
+    def test_old_format_arrival(self):
+        m = ADMIN_CLIP_PATTERN.match("falcon_143025_arrival.mp4")
+        assert m is not None
+        assert m.group("time") == "143025"
+        assert m.group("usec") is None
+        assert m.group("type") == "arrival"
+        assert m.group("ext") == "mp4"
+
+    def test_old_format_visit(self):
+        m = ADMIN_CLIP_PATTERN.match("falcon_080000_visit.mp4")
+        assert m is not None
+        assert m.group("type") == "visit"
+        assert m.group("usec") is None
+
+
+class TestRegexRejectsNonMatches:
+    def test_in_progress_tmp_files_rejected(self):
+        assert ADMIN_CLIP_PATTERN.match("falcon_143025_arrival.mp4.tmp") is None
+        assert ADMIN_CLIP_PATTERN.match("falcon_143025_123456_arrival.mp4.tmp") is None
+
+    def test_log_files_rejected(self):
+        assert ADMIN_CLIP_PATTERN.match("falcon_143025_arrival.ffmpeg.log") is None
+
+    def test_non_falcon_prefix_rejected(self):
+        assert ADMIN_CLIP_PATTERN.match("other_143025_arrival.mp4") is None
+
+    def test_bad_time_length_rejected(self):
+        # 5 digits instead of 6
+        assert ADMIN_CLIP_PATTERN.match("falcon_14302_arrival.mp4") is None
+        # 7 digits — would incorrectly partial-match if anchor was wrong
+        assert ADMIN_CLIP_PATTERN.match("falcon_1430255_arrival.mp4") is None

--- a/tests/test_arrival_confirmation.py
+++ b/tests/test_arrival_confirmation.py
@@ -82,7 +82,9 @@ class TestArrivalConfirmation:
         result_path = save_thumbnail(mock_frame, "clips", timestamp, "arrival")
 
         assert result_path.endswith(".jpg")
-        assert "falcon_103000_arrival" in result_path
+        # 021-I: filename now includes microseconds: falcon_<HHMMSS>_<usec>_<type>
+        assert "falcon_103000_" in result_path
+        assert "_arrival.jpg" in result_path
 
     def test_visit_recorder_rename_to_final(self, tmp_path):
         """Test that visit recorder can rename .tmp file to final."""

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -39,22 +39,41 @@ class TestFormatDuration:
 
 class TestGetOutputPath:
     def test_creates_date_dir_and_correct_filename(self, tmp_path):
+        # microsecond=0 → "000000" in the %f slot (021-I format)
         ts = datetime(2026, 2, 26, 14, 30, 25)
         result = get_output_path(str(tmp_path), ts, "arrival", "mp4")
         expected_dir = tmp_path / "2026-02-26"
         assert expected_dir.exists()
-        assert result == expected_dir / "falcon_143025_arrival.mp4"
+        assert result == expected_dir / "falcon_143025_000000_arrival.mp4"
 
     def test_different_event_types(self, tmp_path):
         ts = datetime(2026, 2, 26, 8, 0, 0)
         for event_type, ext in [("departure", "mp4"), ("visit", "mp4"), ("arrival", "jpg")]:
             path = get_output_path(str(tmp_path), ts, event_type, ext)
-            assert path.name == f"falcon_080000_{event_type}.{ext}"
+            assert path.name == f"falcon_080000_000000_{event_type}.{ext}"
 
     def test_returns_path_object(self, tmp_path):
         ts = datetime(2026, 2, 26, 10, 0, 0)
         result = get_output_path(str(tmp_path), ts, "arrival", "jpg")
         assert isinstance(result, Path)
+
+    def test_same_second_different_microsecond_no_collision(self, tmp_path):
+        """021-I: two events with the same second but different microseconds
+        must produce different paths."""
+        ts1 = datetime(2026, 2, 26, 14, 30, 25, 100000)
+        ts2 = datetime(2026, 2, 26, 14, 30, 25, 200000)
+        p1 = get_output_path(str(tmp_path), ts1, "arrival", "mp4")
+        p2 = get_output_path(str(tmp_path), ts2, "arrival", "mp4")
+        assert p1 != p2
+        assert p1.name == "falcon_143025_100000_arrival.mp4"
+        assert p2.name == "falcon_143025_200000_arrival.mp4"
+
+    def test_microsecond_is_zero_padded_six_digits(self, tmp_path):
+        """Ensure the microsecond slot is exactly 6 digits (zero-padded)."""
+        ts = datetime(2026, 2, 26, 14, 30, 25, 42)  # 42 microseconds
+        result = get_output_path(str(tmp_path), ts, "visit", "mp4")
+        # %f always pads to 6 digits
+        assert result.name == "falcon_143025_000042_visit.mp4"
 
 
 class TestSaveThumbnail:


### PR DESCRIPTION
## Summary

Two events of the same type in the same second could overwrite each other's files. Fix: include microseconds in the filename.

## Format change

| Before | After |
|---|---|
| `falcon_143025_arrival.mp4` | `falcon_143025_123456_arrival.mp4` |

Microsecond uniqueness is deterministic and race-free (unlike a numeric suffix-on-collision retry, which has filesystem race windows and would still need regex updates).

## Admin regex consumers updated

`admin/web/app/services/clip_service.py` had 3 regex sites that parsed clip filenames. All updated to a **backward-compatible** pattern using named groups:

```python
re.compile(
    r"falcon_(?P<time>\d{6})(?:_(?P<usec>\d{6}))?_(?P<type>[a-z]+)\."
    r"(?P<ext>mp4|jpg|jpeg|avi|mov|mkv|png)$"
)
```

The `(?:_\d{6})?` slot makes microseconds optional, so existing on-disk recordings (old format) remain visible after deployment. No mass rename needed.

Named groups remove the position-based unpacking risk from the multi-group regex change.

## Composite-thumbnail lookup also fixed

Two places in `clip_service.py` looked up arrival thumbnails by exact filename (`falcon_{time_str}_arrival.jpg`). New-format thumbnails wouldn't be found. Added a small `_find_thumbnail_at_time()` helper that tries the new-format glob first and falls back to the legacy exact path. Both callers use it.

Without this helper, composite visit thumbnails would silently stop being generated for new recordings.

## Tests

| File | What's tested |
|---|---|
| `tests/test_output.py` | Old asserts updated; new cases for same-second-different-microsecond collision avoidance and zero-padded 6-digit microsecond slot |
| `tests/test_admin_filename_regex_021i.py` | Regex-only test (no admin imports — admin has no test infra). Pins that the pattern accepts BOTH formats, rejects `.tmp`/`.log`/malformed |
| `tests/test_arrival_confirmation.py::test_save_thumbnail` | Substring assert updated to tolerate the microsecond slot |

## Verification

```
pytest tests/ → 268 passed, 4 pre-existing failures unchanged
```

## Migration / rollout note

Existing files on disk (old format) continue to be listed by admin. New recordings use the new format. No data migration needed. If a future change wants to rename existing files into the new format, that's a separate task.

## Related

- Parent: `devlog/Agent-Tasks/021-code-stabilization.md`
- Spec: `devlog/Agent-Tasks/021-I-output-filename-collisions.md`