### PR TITLE
021-J: Recovery confirmation records actual last detection time, not window end

### DIFF
--- a/src/kanyo/detection/buffer_monitor.py
+++ b/src/kanyo/detection/buffer_monitor.py
@@ -195,6 +195,10 @@ class BufferMonitor:
         self.recovery_pending_start: datetime | None = None
         self.recovery_detection_count = 0
         self.recovery_frame_count = 0
+        # Latest detection timestamp seen during the recovery window — passed
+        # to state_machine.confirm_recovery_presence so visit duration is not
+        # inflated by the confirmation window length. See 021-J.
+        self.recovery_latest_detection: datetime | None = None
 
         # Load arrival confirmation config
         self.arrival_confirmation_seconds = (
@@ -302,6 +306,7 @@ class BufferMonitor:
                 self.recovery_frame_count += 1
                 if falcon_detected:
                     self.recovery_detection_count += 1
+                    self.recovery_latest_detection = now
 
                 elapsed = (now - self.recovery_pending_start).total_seconds()
                 if elapsed >= self.stream_recovery_confirmation:
@@ -639,15 +644,20 @@ class BufferMonitor:
             f"({self.recovery_detection_count}/{self.recovery_frame_count} frames)"
         )
 
-        # Confirm recovery in state machine (restores previous state)
+        # Confirm recovery in state machine (restores previous state).
+        # Pass the actual latest detection time so visit duration isn't
+        # inflated by the recovery window length (see 021-J).
         now = get_now_tz(self.full_config)
-        self.state_machine.confirm_recovery_presence(now)
+        self.state_machine.confirm_recovery_presence(
+            now, latest_detection_time=self.recovery_latest_detection
+        )
 
         # Reset recovery pending state only
         self.recovery_pending = False
         self.recovery_pending_start = None
         self.recovery_detection_count = 0
         self.recovery_frame_count = 0
+        self.recovery_latest_detection = None
 
     def _cancel_recovery(self, ratio: float) -> None:
         """Cancel recovery - falcon left during the stream outage.
@@ -674,6 +684,7 @@ class BufferMonitor:
         self.recovery_pending_start = None
         self.recovery_detection_count = 0
         self.recovery_frame_count = 0
+        self.recovery_latest_detection = None
 
     def _reset_pending_states(self) -> None:
         """Reset all pending confirmation states (startup, arrival, and recovery)."""
@@ -691,6 +702,7 @@ class BufferMonitor:
         self.recovery_pending_start = None
         self.recovery_detection_count = 0
         self.recovery_frame_count = 0
+        self.recovery_latest_detection = None
 
     def run(self) -> None:
         """Main monitoring loop."""
@@ -755,6 +767,7 @@ class BufferMonitor:
                         self.recovery_pending_start = now
                         self.recovery_detection_count = 0
                         self.recovery_frame_count = 0
+                        self.recovery_latest_detection = None
 
                         logger.info(
                             f"🔄 Starting recovery confirmation "

--- a/src/kanyo/detection/falcon_state.py
+++ b/src/kanyo/detection/falcon_state.py
@@ -331,7 +331,11 @@ class FalconStateMachine:
             "awaiting confirmation..."
         )
 
-    def confirm_recovery_presence(self, timestamp: datetime) -> None:
+    def confirm_recovery_presence(
+        self,
+        timestamp: datetime,
+        latest_detection_time: datetime | None = None,
+    ) -> None:
         """
         Confirm falcon still present after stream recovery.
 
@@ -339,7 +343,13 @@ class FalconStateMachine:
         No notification is sent - falcon never actually left.
 
         Args:
-            timestamp: Confirmation time
+            timestamp: Confirmation time (end of the recovery window)
+            latest_detection_time: Actual timestamp of the latest detection
+                seen during the confirmation window. If provided, used as
+                last_detection so visit duration does not get inflated by
+                the confirmation window length. Falls back to `timestamp`
+                if None (safety fallback only — successful confirmation
+                should always carry at least one detection). See 021-J.
         """
         if self.state != FalconState.PENDING_RECOVERY:
             logger.warning(f"confirm_recovery_presence called in {self.state} state, ignoring")
@@ -352,7 +362,7 @@ class FalconStateMachine:
         else:
             self.state = FalconState.VISITING
 
-        self.last_detection = timestamp
+        self.last_detection = latest_detection_time or timestamp
         self.last_absence_start = None
         self.pre_outage_state = None
         self.pre_outage_roosting_start = None

--- a/tests/test_recovery_timestamp_021j.py
+++ b/tests/test_recovery_timestamp_021j.py
@@ -1,0 +1,132 @@
+"""Regression tests for 021-J: confirm_recovery_presence must record the
+actual latest detection time, not the confirmation-window end time.
+
+Previously, after a successful recovery, FalconStateMachine.last_detection
+was set to the confirmation moment — inflating visit duration and skewing
+departure clip end frames whenever the bird's actual last detection during
+the confirmation window was earlier than the confirmation moment.
+"""
+
+from datetime import datetime, timedelta
+
+from kanyo.detection.event_types import FalconEvent, FalconState
+from kanyo.detection.falcon_state import FalconStateMachine
+
+
+def _make_pending_recovery() -> FalconStateMachine:
+    """Construct an FSM that is mid-PENDING_RECOVERY after a VISITING outage."""
+    fsm = FalconStateMachine({"exit_timeout": 90, "roosting_threshold": 1800})
+    fsm.initializing = False
+    # Manually drive into VISITING (bypassing initialization gate)
+    visit_start = datetime(2026, 1, 15, 10, 0, 0)
+    fsm.state = FalconState.VISITING
+    fsm.visit_start = visit_start
+    fsm.last_detection = visit_start
+    # Then into PENDING_RECOVERY (e.g. via set_pending_recovery)
+    outage_time = visit_start + timedelta(minutes=5)
+    fsm.set_pending_recovery(outage_time)
+    return fsm
+
+
+class TestConfirmRecoveryRespectsLatestDetectionTime:
+    def test_uses_latest_detection_time_when_provided(self):
+        fsm = _make_pending_recovery()
+        # Bird's actual last frame was 3 seconds before confirmation moment
+        latest_real_detection = datetime(2026, 1, 15, 10, 5, 7)
+        confirmation_moment = datetime(2026, 1, 15, 10, 5, 10)
+
+        fsm.confirm_recovery_presence(
+            confirmation_moment, latest_detection_time=latest_real_detection
+        )
+
+        # last_detection must equal the REAL detection time, not the confirmation moment
+        assert fsm.last_detection == latest_real_detection
+        # Sanity: state restored
+        assert fsm.state == FalconState.VISITING
+
+    def test_falls_back_to_confirmation_time_when_no_detection_passed(self):
+        """Safety fallback: if caller doesn't pass latest_detection_time, the
+        confirmation timestamp is used. This preserves the old behavior for
+        any caller not yet updated to 021-J."""
+        fsm = _make_pending_recovery()
+        confirmation_moment = datetime(2026, 1, 15, 10, 5, 10)
+
+        fsm.confirm_recovery_presence(confirmation_moment)
+
+        assert fsm.last_detection == confirmation_moment
+        assert fsm.state == FalconState.VISITING
+
+    def test_explicit_none_falls_back_to_confirmation_time(self):
+        fsm = _make_pending_recovery()
+        confirmation_moment = datetime(2026, 1, 15, 10, 5, 10)
+
+        fsm.confirm_recovery_presence(confirmation_moment, latest_detection_time=None)
+
+        assert fsm.last_detection == confirmation_moment
+
+    def test_no_effect_when_not_in_pending_recovery(self):
+        """Calling confirm_recovery_presence from a wrong state must be a no-op."""
+        fsm = FalconStateMachine({"exit_timeout": 90, "roosting_threshold": 1800})
+        assert fsm.state == FalconState.ABSENT
+        # Pre-set last_detection to verify it's not overwritten
+        pre_existing = datetime(2026, 1, 15, 9, 0, 0)
+        fsm.last_detection = pre_existing
+
+        fsm.confirm_recovery_presence(
+            datetime(2026, 1, 15, 10, 0, 0),
+            latest_detection_time=datetime(2026, 1, 15, 9, 59, 59),
+        )
+
+        # State stays ABSENT, last_detection NOT changed
+        assert fsm.state == FalconState.ABSENT
+        assert fsm.last_detection == pre_existing
+
+
+class TestVisitDurationNotInflated:
+    """End-to-end: visit duration measured off last_detection is not
+    artificially extended by the confirmation window."""
+
+    def test_visit_duration_reflects_real_last_detection(self):
+        fsm = _make_pending_recovery()
+        # Visit started at 10:00:00, real last detection at 10:05:07
+        # Confirmation moment is at 10:05:10 (3 seconds later)
+        real_last = datetime(2026, 1, 15, 10, 5, 7)
+        confirm_at = datetime(2026, 1, 15, 10, 5, 10)
+
+        fsm.confirm_recovery_presence(confirm_at, latest_detection_time=real_last)
+
+        # Duration computed off (last_detection - visit_start) should be 5:07,
+        # NOT 5:10 (which it would be under the old bug).
+        assert fsm.visit_start is not None
+        assert fsm.last_detection is not None
+        duration = (fsm.last_detection - fsm.visit_start).total_seconds()
+        assert duration == 307.0  # 5 minutes 7 seconds, not 310
+        # Old bug would give 310.0 — pin the difference
+        assert duration < 310.0
+
+
+class TestBufferMonitorPassesLatestDetectionTime:
+    """Source-level check that _confirm_recovery passes recovery_latest_detection
+    to state_machine.confirm_recovery_presence."""
+
+    def test_confirm_recovery_passes_latest_detection_kwarg(self):
+        from pathlib import Path
+
+        src = Path(__file__).parent.parent / "src" / "kanyo" / "detection" / "buffer_monitor.py"
+        text = src.read_text()
+        # Find the _confirm_recovery method body
+        idx_method = text.find("def _confirm_recovery(")
+        assert idx_method != -1, "_confirm_recovery method not found"
+        # Look in the next ~1000 chars
+        body = text[idx_method : idx_method + 1500]
+        assert "latest_detection_time=" in body, (
+            "_confirm_recovery must pass latest_detection_time= to "
+            "state_machine.confirm_recovery_presence (021-J)"
+        )
+        assert (
+            "recovery_latest_detection" in body
+        ), "_confirm_recovery must reference recovery_latest_detection (021-J)"
+
+
+# silence unused import warnings if any
+_ = FalconEvent


### PR DESCRIPTION
## Summary

After a successful stream-recovery confirmation, `FalconStateMachine.last_detection` was being set to the confirmation moment instead of the bird's actual last detection time during the confirmation window. Result: visit duration inflated by up to `stream_recovery_confirmation` seconds, and departure clip end frames drifted forward by the same amount.

## Fix

**`FalconStateMachine.confirm_recovery_presence`** now accepts an optional `latest_detection_time` kwarg:

```python
def confirm_recovery_presence(
    self,
    timestamp: datetime,
    latest_detection_time: datetime | None = None,
) -> None:
    ...
    self.last_detection = latest_detection_time or timestamp
```

Falls back to the confirmation timestamp if not provided (safety fallback only — successful confirmation should always carry at least one detection).

**`BufferMonitor`** tracks `recovery_latest_detection` during the recovery window — updated every time `falcon_detected is True` while `recovery_pending`. `_confirm_recovery` passes that value through. The new attribute is reset at all 4 sites where recovery pending state is reset (init, `_confirm_recovery`, `_cancel_recovery`, `_reset_pending_states`, and the outage-detection start in the main loop).

## Numerical example

Visit starts at `10:00:00`. Bird's actual last frame at `10:05:07`. Confirmation window ends at `10:05:10`.

| | `last_detection` | duration |
|---|---|---|
| Before | `10:05:10` (confirmation moment) | 310s |
| After | `10:05:07` (real last detection) | 307s |

The 3-second drift compounds across many recoveries and was particularly visible on streams with longer recovery windows.

## Tests

`tests/test_recovery_timestamp_021j.py` — 6 cases:

| Test | Pins |
|---|---|
| `test_uses_latest_detection_time_when_provided` | The 021-J behavior |
| `test_falls_back_to_confirmation_time_when_no_detection_passed` | Safety fallback for any unupdated caller |
| `test_explicit_none_falls_back_to_confirmation_time` | None handling |
| `test_no_effect_when_not_in_pending_recovery` | Wrong-state guard preserves pre-existing `last_detection` |
| `test_visit_duration_reflects_real_last_detection` | End-to-end duration check — explicit `307s, not 310s` assertion so a future revert is loud |
| `test_confirm_recovery_passes_latest_detection_kwarg` | Source-level check on `_confirm_recovery` |

## Verification

```
pytest tests/test_recovery_timestamp_021j.py tests/test_falcon_state.py → 37 passed
pytest tests/                                                            → 264 passed, 4 pre-existing failures
```

## Related

- Parent: `devlog/Agent-Tasks/021-code-stabilization.md`
- Spec: `devlog/Agent-Tasks/021-J-recovery-timestamp-drift.md`