### PR TITLE
022-B: Fix ROOSTING log duration — read visit_duration_seconds metadata key

### DIFF
--- a/src/kanyo/detection/event_handler.py
+++ b/src/kanyo/detection/event_handler.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from kanyo.detection.event_types import FalconEvent
 from kanyo.utils.logger import get_logger
 from kanyo.utils.notifications import NotificationManager
-from kanyo.utils.output import save_thumbnail, format_duration
+from kanyo.utils.output import format_duration, save_thumbnail
 
 logger = get_logger(__name__)
 
@@ -99,5 +99,5 @@ class FalconEventHandler:
                 self.notifications.send_departure(timestamp, thumb_path, duration_str)
 
         elif event_type == FalconEvent.ROOSTING:
-            duration_str = format_duration(metadata.get("visit_duration", 0))
+            duration_str = format_duration(metadata.get("visit_duration_seconds", 0))
             logger.event(f"🏠 FALCON ROOSTING - settled for long-term stay (visit: {duration_str})")

--- a/tests/test_event_handler.py
+++ b/tests/test_event_handler.py
@@ -1,11 +1,13 @@
 """Tests for FalconEventHandler."""
+
+import logging
 from datetime import datetime
-from unittest.mock import Mock, patch, call
+from unittest.mock import Mock, call, patch
 
 import pytest
 
-from kanyo.detection.event_types import FalconEvent
 from kanyo.detection.event_handler import FalconEventHandler
+from kanyo.detection.event_types import FalconEvent
 
 
 class TestFalconEventHandlerInit:
@@ -49,14 +51,14 @@ class TestFalconEventHandlerArrival:
         mock_notifs = Mock()
         import numpy as np
 
-        handler = FalconEventHandler(
-            notifications=mock_notifs, clips_dir=str(tmp_path)
-        )
+        handler = FalconEventHandler(notifications=mock_notifs, clips_dir=str(tmp_path))
         frame = np.zeros((480, 640, 3), dtype=np.uint8)
         handler.update_frame(frame)
         ts = datetime(2026, 2, 26, 10, 0, 0)
 
-        with patch("kanyo.detection.event_handler.save_thumbnail", return_value="/tmp/thumb.jpg") as mock_save:
+        with patch(
+            "kanyo.detection.event_handler.save_thumbnail", return_value="/tmp/thumb.jpg"
+        ) as mock_save:
             handler.handle_event(FalconEvent.ARRIVED, ts, {})
 
         mock_save.assert_called_once()
@@ -91,9 +93,7 @@ class TestFalconEventHandlerDeparture:
         mock_notifs = Mock()
         import numpy as np
 
-        handler = FalconEventHandler(
-            notifications=mock_notifs, clips_dir=str(tmp_path)
-        )
+        handler = FalconEventHandler(notifications=mock_notifs, clips_dir=str(tmp_path))
         frame = np.zeros((480, 640, 3), dtype=np.uint8)
         handler.update_frame(frame)
         ts = datetime(2026, 2, 26, 10, 30, 0)
@@ -110,4 +110,25 @@ class TestFalconEventHandlerRoosting:
         handler = FalconEventHandler()
         ts = datetime(2026, 2, 26, 10, 0, 0)
         # Should not raise
-        handler.handle_event(FalconEvent.ROOSTING, ts, {"visit_duration": 3600})
+        handler.handle_event(FalconEvent.ROOSTING, ts, {"visit_duration_seconds": 3600})
+
+    def test_roosting_logs_real_visit_duration(self, caplog):
+        """ROOSTING reads visit_duration_seconds (the key falcon_state emits), not 0s.
+
+        Regression test for 022-B: the handler read the nonexistent
+        'visit_duration' key, so every ROOSTING line showed '(visit: 0s)'.
+        """
+        handler = FalconEventHandler()
+        ts = datetime(2026, 2, 26, 10, 0, 0)
+
+        with caplog.at_level(logging.INFO, logger="kanyo.detection.event_handler"):
+            handler.handle_event(
+                FalconEvent.ROOSTING,
+                ts,
+                {"visit_start": ts, "visit_duration_seconds": 1800, "roosting_start": ts},
+            )
+
+        roosting_lines = [r.message for r in caplog.records if "ROOSTING" in r.message]
+        assert roosting_lines, "expected a ROOSTING log line"
+        assert "(visit: 30m)" in roosting_lines[0]
+        assert "(visit: 0s)" not in roosting_lines[0]


### PR DESCRIPTION
## Diagnosis

`falcon_state.py` emits the ROOSTING event with metadata key `visit_duration_seconds`, but `event_handler.py` read `metadata.get("visit_duration", 0)` — a key that never exists. Every ROOSTING log line therefore showed "(visit: 0s)". The DEPARTED branch already reads the correct key; only ROOSTING was wrong.

## Change

- `src/kanyo/detection/event_handler.py`: read `visit_duration_seconds` in the ROOSTING branch (one line).
- `tests/test_event_handler.py`: regression test asserting the ROOSTING line carries the real formatted duration (30m for 1800s) and not "(visit: 0s)"; updated the existing roosting smoke test to use the real key.

## Verification

- black + isort applied to changed files; mypy src/ clean.
- pytest: 301 passed; the only failures are the 4 pre-existing environment-dependent failures already on main (test_detection blank-frame, 3 test_log_service show-context tests).