### PR TITLE
022-D: Gate stream-reconnected admin alert on a sent lost alert

### DIFF
--- a/src/kanyo/detection/capture.py
+++ b/src/kanyo/detection/capture.py
@@ -78,6 +78,9 @@ class StreamCapture:
         self._ytdlp_fallback_used = False
         self.ytdlp_opts: dict = {}
         self._last_admin_notification_time: float = 0
+        # True only while a "lost" admin alert has been sent and not yet paired
+        # with a "reconnected" alert — keeps connectivity alerts in matched pairs.
+        self._outage_alert_sent: bool = False
         self._consecutive_failures = 0
         self._attempts_today = 0
         self._attempts_window_start = time.time()
@@ -268,13 +271,18 @@ class StreamCapture:
                     ):
                         self.on_connection_issue(f"Stream connection lost: {self.stream_url}")
                         self._last_admin_notification_time = time.time()
+                        self._outage_alert_sent = True
 
                     if not self.reconnect():
                         continue  # reconnect() sleeps via connect() backoff
 
                     logger.info("✅ Reconnected successfully!")
-                    if self.on_connection_issue:
+                    # Only send "reconnected" when a matching "lost" alert was
+                    # actually sent (the lost alert is throttled to 1/hour;
+                    # unpaired reconnect alerts were pure noise — see 022-D).
+                    if self.on_connection_issue and self._outage_alert_sent:
                         self.on_connection_issue("Stream reconnected")
+                        self._outage_alert_sent = False
                     continue
 
                 # Skip frames if requested

--- a/tests/test_connection_notifications.py
+++ b/tests/test_connection_notifications.py
@@ -1,7 +1,8 @@
 """Tests for connection failure notification feature."""
 
-from unittest.mock import MagicMock, patch
 import time
+from unittest.mock import MagicMock, patch
+
 from kanyo.detection.capture import StreamCapture
 
 
@@ -161,6 +162,61 @@ class TestConnectionNotifications:
         # Seventh failure: capped at 300s
         backoff7 = min(5.0 * (2**6), max_backoff)
         assert backoff7 == 300.0
+
+
+class TestReconnectAlertGating:
+    """Reconnected alerts must come in matched pairs with sent lost alerts (022-D)."""
+
+    @staticmethod
+    def _fake_frame():
+        frame = MagicMock()
+        frame.frame_number = 1
+        return frame
+
+    def test_no_reconnected_alert_when_lost_alert_throttled(self):
+        """Reconnect after a throttled (unsent) lost alert produces no alert at all."""
+        messages = []
+        capture = StreamCapture(
+            "https://example.com/test.mp4",
+            on_connection_issue=messages.append,
+        )
+        # A lost alert went out recently — the next one is inside the throttle window
+        capture._last_admin_notification_time = time.time() - 60
+        capture._outage_alert_sent = False  # that outage already got its "reconnected"
+
+        # One read failure, then a good frame so the generator yields and we stop
+        with patch.object(capture, "connect", return_value=True):
+            with patch.object(capture, "reconnect", return_value=True):
+                with patch.object(capture, "read_frame", side_effect=[None, self._fake_frame()]):
+                    gen = capture.frames()
+                    next(gen)
+                    gen.close()
+
+        assert messages == []
+
+    def test_reconnected_alert_paired_with_sent_lost_alert(self):
+        """A sent lost alert is followed by exactly one reconnected alert; a
+        subsequent reconnect inside the throttle window produces nothing."""
+        messages = []
+        capture = StreamCapture(
+            "https://example.com/test.mp4",
+            on_connection_issue=messages.append,
+        )
+        capture._last_admin_notification_time = 0  # outside throttle window
+
+        # Two failure/recovery cycles: fail, frame, fail, frame
+        side_effects = [None, self._fake_frame(), None, self._fake_frame()]
+        with patch.object(capture, "connect", return_value=True):
+            with patch.object(capture, "reconnect", return_value=True):
+                with patch.object(capture, "read_frame", side_effect=side_effects):
+                    gen = capture.frames()
+                    next(gen)  # first cycle: lost alert sent → reconnected sent
+                    next(gen)  # second cycle: lost throttled → reconnected gated
+                    gen.close()
+
+        assert len(messages) == 2
+        assert "connection lost" in messages[0].lower()
+        assert "reconnected" in messages[1].lower()
 
 
 class TestNotificationManagerIntegration:


### PR DESCRIPTION
## Diagnosis

In `StreamCapture.frames()` the "Stream connection lost" admin alert is throttled to once per hour, but "Stream reconnected" fired unconditionally after every successful reconnect. Every transient read failure that reconnected inside the throttle window produced an orphan "reconnected" message — observed 20+/day in production.

## Change

- `src/kanyo/detection/capture.py`: new `_outage_alert_sent` flag on `StreamCapture`; set when a lost alert is actually sent, and the reconnected alert now fires only when the flag is set, then clears it. The 1/hour lost-alert throttle and reconnect/backoff behavior are untouched.
- `tests/test_connection_notifications.py`: two regression tests driving `frames()` — reconnect after a throttled lost alert produces no alert at all; a sent lost alert is followed by exactly one reconnected alert and a second failure/reconnect cycle inside the throttle window produces nothing.

## Verification

- black + isort applied to changed files; mypy src/ clean.
- pytest: 303 passed; only the 4 pre-existing environment-dependent failures already on main.