### PR TITLE
022-A: Populate peak_confidence and departure_clip_path in visit records

### DIFF
--- a/src/kanyo/detection/buffer_monitor.py
+++ b/src/kanyo/detection/buffer_monitor.py
@@ -176,6 +176,15 @@ class BufferMonitor:
         self.last_detection_time: datetime | None = None
         self._frame_size: tuple[int, int] | None = None
 
+        # Visit-scoped peak detection confidence (022-A). Running max across
+        # all detection polls of the current visit; written into the
+        # FalconVisit row on departure. Reset on visit start and on every
+        # path that closes or cancels a visit.
+        self._visit_peak_confidence: float = 0.0
+        # Max confidence of the most recent detection poll (0.0 when the poll
+        # saw nothing) — used to seed the visit peak on ARRIVED.
+        self._frame_peak_confidence: float = 0.0
+
         # Arrival clip recorder (short-duration, parallel to visit recorder)
         self.arrival_clip_recorder = ArrivalClipRecorder(self.clip_manager)
         # Arrival confirmation state
@@ -209,8 +218,12 @@ class BufferMonitor:
         )
 
         # Roosting mode config
-        self.roosting_recording_mode = (full_config or {}).get("roosting_recording_mode", "continuous")
-        self.roosting_detection_interval = (full_config or {}).get("roosting_detection_interval", 30)
+        self.roosting_recording_mode = (full_config or {}).get(
+            "roosting_recording_mode", "continuous"
+        )
+        self.roosting_detection_interval = (full_config or {}).get(
+            "roosting_detection_interval", 30
+        )
         self.roosting_mode_active = False
         self.last_roosting_check: datetime | None = None
         self._roosting_visit_metadata: dict | None = None
@@ -266,6 +279,13 @@ class BufferMonitor:
             # Run detection
             detections = self.detector.detect_birds(frame_data, timestamp=now)
             falcon_detected = len(detections) > 0
+
+            # Track visit-scoped peak confidence (022-A)
+            self._frame_peak_confidence = max((d.confidence for d in detections), default=0.0)
+            if falcon_detected:
+                self._visit_peak_confidence = max(
+                    self._visit_peak_confidence, self._frame_peak_confidence
+                )
 
             # Startup confirmation logic (similar to arrival, but no telegram until confirmed)
             if self.startup_pending and self.startup_pending_start is not None:
@@ -366,6 +386,10 @@ class BufferMonitor:
             self.arrival_detection_count = 1
             self.arrival_frame_count = 1
 
+            # New visit: discard any stale peak and seed with the arriving
+            # frame's confidence (022-A)
+            self._visit_peak_confidence = self._frame_peak_confidence
+
             # Get lead-in frames from buffer
             lead_in_frames = self.frame_buffer.get_frames_before(
                 event_time, self.visit_recorder.lead_in_seconds
@@ -402,8 +426,9 @@ class BufferMonitor:
             # Handle departure from roosting stop mode (visit recorder already stopped)
             if self.roosting_mode_active and self.roosting_recording_mode == "stop":
                 logger.event("🦅 DEPARTURE from roost — extracting departure clip from buffer")
-                self.clip_manager.create_clip_from_buffer(
-                    event_time, "departure",
+                departure_clip_scheduled = self.clip_manager.create_clip_from_buffer(
+                    event_time,
+                    "departure",
                     before_seconds=self.clip_manager.clip_departure_before,
                     after_seconds=self.clip_manager.clip_departure_after,
                 )
@@ -412,23 +437,36 @@ class BufferMonitor:
                     if isinstance(visit_start_dt, str):
                         visit_start_dt = datetime.fromisoformat(visit_start_dt)
                     last_detection_time = metadata.get("visit_end", event_time)
+                    visit_end_dt = last_detection_time
+                    if isinstance(visit_end_dt, str):
+                        visit_end_dt = datetime.fromisoformat(visit_end_dt)
                     arrival_clip_path = get_output_path(
                         self.clips_dir, visit_start_dt, "arrival", "mp4"
                     )
                     thumbnail_path = get_output_path(
                         self.clips_dir, visit_start_dt, "arrival", "jpg"
                     )
+                    # Departure clip path derived with the same expression the
+                    # clip manager uses, so the paths agree by construction.
+                    # Not gated on Path.exists() — extraction runs
+                    # asynchronously on the clip manager's executor (022-A).
+                    departure_clip_path = get_output_path(
+                        self.clips_dir, visit_end_dt, "departure", "mp4"
+                    )
                     visit = FalconVisit(
                         start_time=metadata["visit_start"],
                         end_time=last_detection_time,
+                        peak_confidence=self._visit_peak_confidence,
                         arrival_clip_path=(
                             str(arrival_clip_path) if arrival_clip_path.exists() else None
                         ),
-                        thumbnail_path=(
-                            str(thumbnail_path) if thumbnail_path.exists() else None
+                        thumbnail_path=(str(thumbnail_path) if thumbnail_path.exists() else None),
+                        departure_clip_path=(
+                            str(departure_clip_path) if departure_clip_scheduled else None
                         ),
                     )
                     self.event_store.append(visit)
+                self._visit_peak_confidence = 0.0
                 self.roosting_mode_active = False
                 self.last_roosting_check = None
                 self._roosting_visit_metadata = None
@@ -456,13 +494,16 @@ class BufferMonitor:
                 visit_metadata["visit_end"] = last_detection_time
 
                 # Create departure clip
-                self.clip_manager.create_departure_clip(visit_metadata)
+                departure_clip_scheduled = self.clip_manager.create_departure_clip(visit_metadata)
 
                 # Save visit metadata to event store
                 if "visit_start" in metadata and "visit_end" in metadata:
                     visit_start_dt = metadata["visit_start"]
                     if isinstance(visit_start_dt, str):
                         visit_start_dt = datetime.fromisoformat(visit_start_dt)
+                    visit_end_dt = metadata["visit_end"]
+                    if isinstance(visit_end_dt, str):
+                        visit_end_dt = datetime.fromisoformat(visit_end_dt)
 
                     # Derive arrival clip and thumbnail paths from arrival timestamp
                     arrival_clip_path = get_output_path(
@@ -471,21 +512,33 @@ class BufferMonitor:
                     thumbnail_path = get_output_path(
                         self.clips_dir, visit_start_dt, "arrival", "jpg"
                     )
+                    # Departure clip path derived with the same expression the
+                    # clip manager uses, so the paths agree by construction.
+                    # Not gated on Path.exists() — extraction runs
+                    # asynchronously on the clip manager's executor (022-A).
+                    departure_clip_path = get_output_path(
+                        self.clips_dir, visit_end_dt, "departure", "mp4"
+                    )
 
                     visit = FalconVisit(
                         start_time=metadata["visit_start"],
                         end_time=metadata["visit_end"],
+                        peak_confidence=self._visit_peak_confidence,
                         arrival_clip_path=(
                             str(arrival_clip_path) if arrival_clip_path.exists() else None
                         ),
-                        thumbnail_path=(
-                            str(thumbnail_path) if thumbnail_path.exists() else None
+                        thumbnail_path=(str(thumbnail_path) if thumbnail_path.exists() else None),
+                        departure_clip_path=(
+                            str(departure_clip_path) if departure_clip_scheduled else None
                         ),
                     )
                     self.event_store.append(visit)
 
                     duration = visit_metadata.get("duration_seconds", 0)
                     logger.event(f"✅ Visit recorded: {duration:.0f}s → {visit_path}")
+
+            # Visit is over — reset the visit-scoped peak (022-A)
+            self._visit_peak_confidence = 0.0
 
         elif event_type == FalconEvent.ROOSTING:
             if self.roosting_recording_mode == "stop":
@@ -560,6 +613,9 @@ class BufferMonitor:
 
         # Reset state machine to ABSENT
         self.state_machine.reset_to_absent()
+
+        # Cancelled visit — discard its peak confidence (022-A)
+        self._visit_peak_confidence = 0.0
 
         # Reset pending state
         self.arrival_pending = False
@@ -693,6 +749,10 @@ class BufferMonitor:
 
     def _reset_pending_states(self) -> None:
         """Reset all pending confirmation states (startup, arrival, and recovery)."""
+        # Any visit in progress is being abandoned (cancelled startup or
+        # outage-exceeded reset) — discard its peak confidence (022-A)
+        self._visit_peak_confidence = 0.0
+
         self.startup_pending = False
         self.startup_pending_start = None
         self.startup_detection_count = 0
@@ -799,6 +859,9 @@ class BufferMonitor:
                         state_name = initial_state.value
                         if falcon_detected:
                             max_conf = max(d.confidence for d in initial_detections)
+
+                            # Seed the visit peak from startup init detections (022-A)
+                            self._visit_peak_confidence = max_conf
 
                             # If falcon detected, state is PENDING_STARTUP
                             # We need to confirm presence before transitioning to ROOSTING

--- a/tests/test_visit_record_fields.py
+++ b/tests/test_visit_record_fields.py
@@ -1,0 +1,242 @@
+"""Tests for 022-A: peak_confidence and departure_clip_path in FalconVisit records.
+
+Both fields exist on the dataclass and are serialized, but before 022-A neither
+FalconVisit construction site in buffer_monitor populated them — all production
+rows showed peak_confidence 0.0 and departure_clip_path null.
+"""
+
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from kanyo.detection.buffer_monitor import BufferMonitor
+from kanyo.detection.event_types import FalconEvent
+from kanyo.detection.events import FalconVisit
+from kanyo.utils.output import get_output_path
+
+
+def make_monitor(clips_dir: str = "clips", roosting_recording_mode: str = "continuous"):
+    """Return a BufferMonitor with all external dependencies mocked out."""
+    with (
+        patch("kanyo.detection.buffer_monitor.StreamCapture"),
+        patch("kanyo.detection.buffer_monitor.FalconDetector"),
+        patch("kanyo.detection.buffer_monitor.FrameBuffer"),
+        patch("kanyo.detection.buffer_monitor.VisitRecorder"),
+        patch("kanyo.detection.buffer_monitor.BufferClipManager"),
+        patch("kanyo.detection.buffer_monitor.EventStore"),
+        patch("kanyo.detection.buffer_monitor.FalconEventHandler"),
+        patch("kanyo.detection.buffer_monitor.FalconStateMachine"),
+        patch("kanyo.detection.buffer_monitor.ArrivalClipRecorder"),
+    ):
+        monitor = BufferMonitor(
+            stream_url="test",
+            clips_dir=clips_dir,
+            full_config={
+                "roosting_recording_mode": roosting_recording_mode,
+                "roosting_detection_interval": 30,
+                "arrival_confirmation_seconds": 10,
+                "arrival_confirmation_ratio": 0.3,
+            },
+        )
+    return monitor
+
+
+def detection(conf: float):
+    """Minimal stand-in for a Detection with a confidence attribute."""
+    return SimpleNamespace(confidence=conf)
+
+
+def _quiet_frame_mocks(monitor) -> None:
+    """Configure recorder/buffer mocks so process_frame runs the poll path."""
+    monitor.visit_recorder.is_recording = False
+    monitor.arrival_clip_recorder.is_recording.return_value = False
+    monitor.frame_buffer.add_frame.return_value = None
+    monitor.state_machine.update.return_value = []
+
+
+class TestPeakConfidenceTracking:
+    def test_process_frame_tracks_running_max(self):
+        """The visit peak is the max confidence across all detection polls."""
+        monitor = make_monitor()
+        _quiet_frame_mocks(monitor)
+        monitor.detector.detect_birds.side_effect = [
+            [detection(0.4)],
+            [detection(0.8), detection(0.5)],
+            [],
+            [detection(0.6)],
+        ]
+
+        now = datetime(2026, 7, 1, 10, 0, 0)
+        frame = MagicMock()
+        frame.shape = (720, 1280, 3)
+        with patch("kanyo.detection.buffer_monitor.get_now_tz", return_value=now):
+            for n in range(4):
+                monitor.process_frame(frame, frame_number=n)
+
+        assert monitor._visit_peak_confidence == 0.8
+
+    def test_arrived_seeds_peak_from_arriving_frame(self):
+        """ARRIVED discards any stale peak and seeds with the arriving frame's confidence."""
+        monitor = make_monitor()
+        monitor._visit_peak_confidence = 0.99  # stale value from a prior visit
+        monitor._frame_peak_confidence = 0.55  # arriving frame's poll
+        monitor.frame_buffer.get_frames_before.return_value = []
+
+        monitor._handle_event(FalconEvent.ARRIVED, datetime(2026, 7, 1, 10, 0, 0), {})
+
+        assert monitor._visit_peak_confidence == 0.55
+
+    def test_cancel_arrival_resets_peak(self):
+        monitor = make_monitor()
+        monitor._visit_peak_confidence = 0.7
+        monitor.arrival_clip_recorder.get_temp_path.return_value = None
+        monitor.visit_recorder.get_temp_path.return_value = None
+
+        monitor._cancel_arrival(ratio=0.1)
+
+        assert monitor._visit_peak_confidence == 0.0
+
+    def test_reset_pending_states_resets_peak(self):
+        """Outage-exceeded and cancelled-startup paths discard the visit peak."""
+        monitor = make_monitor()
+        monitor._visit_peak_confidence = 0.7
+
+        monitor._reset_pending_states()
+
+        assert monitor._visit_peak_confidence == 0.0
+
+
+class TestNormalDepartureVisitRecord:
+    def _departure(self, monitor, visit_start, visit_end, clip_scheduled: bool):
+        monitor.arrival_pending = False
+        monitor.arrival_clip_recorder.is_recording.return_value = False
+        monitor.visit_recorder.stop_recording.return_value = (
+            "/fake/visit.mp4",
+            {"visit_start": visit_start, "duration_seconds": 1200},
+        )
+        monitor.clip_manager.create_departure_clip.return_value = clip_scheduled
+
+        metadata = {"visit_start": visit_start, "visit_end": visit_end}
+        monitor._handle_event(FalconEvent.DEPARTED, visit_end + timedelta(seconds=90), metadata)
+
+    def test_row_carries_peak_and_departure_clip_path(self, tmp_path):
+        monitor = make_monitor(clips_dir=str(tmp_path))
+        monitor._visit_peak_confidence = 0.77
+        visit_start = datetime(2026, 7, 1, 10, 0, 0)
+        visit_end = datetime(2026, 7, 1, 10, 20, 0)
+
+        self._departure(monitor, visit_start, visit_end, clip_scheduled=True)
+
+        monitor.event_store.append.assert_called_once()
+        visit = monitor.event_store.append.call_args[0][0]
+        assert isinstance(visit, FalconVisit)
+        assert visit.peak_confidence == 0.77
+        expected = str(get_output_path(str(tmp_path), visit_end, "departure", "mp4"))
+        assert visit.departure_clip_path == expected
+
+    def test_departure_clip_path_none_when_scheduling_failed(self, tmp_path):
+        monitor = make_monitor(clips_dir=str(tmp_path))
+        monitor._visit_peak_confidence = 0.42
+        visit_start = datetime(2026, 7, 1, 10, 0, 0)
+        visit_end = datetime(2026, 7, 1, 10, 20, 0)
+
+        self._departure(monitor, visit_start, visit_end, clip_scheduled=False)
+
+        visit = monitor.event_store.append.call_args[0][0]
+        assert visit.peak_confidence == 0.42
+        assert visit.departure_clip_path is None
+
+    def test_peak_resets_between_visits(self, tmp_path):
+        """A second visit does not inherit the first visit's peak."""
+        monitor = make_monitor(clips_dir=str(tmp_path))
+        monitor._visit_peak_confidence = 0.9
+        visit_start = datetime(2026, 7, 1, 10, 0, 0)
+        visit_end = datetime(2026, 7, 1, 10, 20, 0)
+
+        self._departure(monitor, visit_start, visit_end, clip_scheduled=True)
+        assert monitor._visit_peak_confidence == 0.0
+
+        # Second visit arrives with a weaker detection
+        monitor._frame_peak_confidence = 0.3
+        monitor.frame_buffer.get_frames_before.return_value = []
+        monitor._handle_event(FalconEvent.ARRIVED, datetime(2026, 7, 1, 11, 0, 0), {})
+        assert monitor._visit_peak_confidence == 0.3
+
+    def test_parses_isoformat_visit_end(self, tmp_path):
+        """String visit_end is parsed for the departure clip path derivation.
+
+        visit_start stays a datetime: FalconVisit.__post_init__ derives its id
+        via start_time.strftime, so a string start_time is not constructible
+        (pre-existing constraint; the state machine always emits datetimes).
+        """
+        monitor = make_monitor(clips_dir=str(tmp_path))
+        visit_start = datetime(2026, 7, 1, 10, 0, 0)
+        visit_end = datetime(2026, 7, 1, 10, 20, 0)
+
+        monitor.arrival_pending = False
+        monitor.arrival_clip_recorder.is_recording.return_value = False
+        monitor.visit_recorder.stop_recording.return_value = (
+            "/fake/visit.mp4",
+            {"visit_start": visit_start, "duration_seconds": 1200},
+        )
+        monitor.clip_manager.create_departure_clip.return_value = True
+
+        metadata = {
+            "visit_start": visit_start,
+            "visit_end": visit_end.isoformat(),
+        }
+        monitor._handle_event(FalconEvent.DEPARTED, visit_end + timedelta(seconds=90), metadata)
+
+        visit = monitor.event_store.append.call_args[0][0]
+        expected = str(get_output_path(str(tmp_path), visit_end, "departure", "mp4"))
+        assert visit.departure_clip_path == expected
+
+
+class TestRoostingStopDepartureVisitRecord:
+    def _roost_departure(self, monitor, visit_start, visit_end, clip_scheduled: bool):
+        monitor.roosting_mode_active = True
+        monitor._roosting_visit_metadata = {"visit_start": visit_start}
+        monitor.clip_manager.clip_departure_before = 30
+        monitor.clip_manager.clip_departure_after = 15
+        monitor.clip_manager.create_clip_from_buffer.return_value = clip_scheduled
+        monitor.arrival_pending = False
+        monitor.arrival_clip_recorder.is_recording.return_value = False
+
+        metadata = {"visit_start": visit_start, "visit_end": visit_end}
+        monitor._handle_event(FalconEvent.DEPARTED, visit_end, metadata)
+
+    def test_row_carries_peak_and_departure_clip_path(self, tmp_path):
+        monitor = make_monitor(clips_dir=str(tmp_path), roosting_recording_mode="stop")
+        monitor._visit_peak_confidence = 0.66
+        visit_start = datetime(2026, 7, 1, 8, 0, 0)
+        visit_end = datetime(2026, 7, 1, 11, 0, 0)
+
+        self._roost_departure(monitor, visit_start, visit_end, clip_scheduled=True)
+
+        monitor.event_store.append.assert_called_once()
+        visit = monitor.event_store.append.call_args[0][0]
+        assert isinstance(visit, FalconVisit)
+        assert visit.peak_confidence == 0.66
+        expected = str(get_output_path(str(tmp_path), visit_end, "departure", "mp4"))
+        assert visit.departure_clip_path == expected
+
+    def test_departure_clip_path_none_when_scheduling_failed(self, tmp_path):
+        monitor = make_monitor(clips_dir=str(tmp_path), roosting_recording_mode="stop")
+        monitor._visit_peak_confidence = 0.66
+        visit_start = datetime(2026, 7, 1, 8, 0, 0)
+        visit_end = datetime(2026, 7, 1, 11, 0, 0)
+
+        self._roost_departure(monitor, visit_start, visit_end, clip_scheduled=False)
+
+        visit = monitor.event_store.append.call_args[0][0]
+        assert visit.departure_clip_path is None
+
+    def test_peak_reset_after_roosting_departure(self, tmp_path):
+        monitor = make_monitor(clips_dir=str(tmp_path), roosting_recording_mode="stop")
+        monitor._visit_peak_confidence = 0.66
+        visit_start = datetime(2026, 7, 1, 8, 0, 0)
+        visit_end = datetime(2026, 7, 1, 11, 0, 0)
+
+        self._roost_departure(monitor, visit_start, visit_end, clip_scheduled=True)
+
+        assert monitor._visit_peak_confidence == 0.0


### PR DESCRIPTION
## Diagnosis

All 1,449 production `FalconVisit` rows show `peak_confidence: 0.0` and `departure_clip_path: null`. Both fields exist on the dataclass and are serialized, but neither construction site in `buffer_monitor.py::_handle_event` (roosting-stop departure, normal departure) ever populated them, and nothing tracked a running max of detection confidence per visit.

## Change

`src/kanyo/detection/buffer_monitor.py`:
- New visit-scoped `_visit_peak_confidence` (plus `_frame_peak_confidence` for the latest poll), updated to the running max on every detection poll in `process_frame`.
- Seeded on ARRIVED with the arriving frame's confidence, and from `initial_detections` on the startup-presence path in `run()`.
- Reset on every path that closes or cancels a visit: both DEPARTED construction sites, `_cancel_arrival`, and `_reset_pending_states` (covers `_cancel_startup_presence` and both outage-exceeded resets).
- Both `FalconVisit` sites now pass `peak_confidence` and `departure_clip_path`. The departure path is computed with the same `get_output_path(clips_dir, visit_end, "departure", "mp4")` expression the clip manager uses, so paths agree by construction; it is recorded when clip creation was scheduled (returned True), never gated on `Path.exists()` (extraction is async on the clip-manager executor). `visit_end` gets the same isinstance/fromisoformat guard the sites already use for `visit_start`.

`tests/test_visit_record_fields.py` (new): running-max tracking through `process_frame`; ARRIVED seeding/reset; cancel-path resets; both departure paths carrying peak + clip path; `None` when scheduling returned False; no peak inheritance between visits; isoformat `visit_end` parsing.

## Verification

- black + isort applied to changed files; mypy src/ clean.
- pytest: 314 passed (11 new); only the 4 pre-existing environment-dependent failures already on main.