### PR TITLE
022-E: Add periodic rolling detection-confidence summary

### DIFF
--- a/configs/config.template.yaml
+++ b/configs/config.template.yaml
@@ -53,12 +53,20 @@ video_source: "https://youtube.com/watch?v=YOUR_STREAM_ID"
 #   (bird, cat, dog, etc.) as a potential falcon presence. This catches cases
 #   where the model classifies the falcon as a generic "bird". Set false only
 #   if you have a custom model trained specifically for your species.
+#
+# detection_summary_interval — Seconds between rolling detection-confidence
+#   summary lines in the log (EVENT level). Each summary aggregates every
+#   detection poll since the last one: poll count, detection ratio, and
+#   min/median/max confidence across detected polls. This is the data source
+#   for tuning detection_confidence / detection_confidence_ir from production
+#   logs. 300 (5 minutes) is a good default; set 0 to disable entirely.
 
 detection_confidence: 0.3
 detection_confidence_ir: 0.25
 frame_interval: 3
 model_path: "models/yolov8n.pt"
 detect_any_animal: true
+detection_summary_interval: 300
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/src/kanyo/detection/buffer_monitor.py
+++ b/src/kanyo/detection/buffer_monitor.py
@@ -9,6 +9,7 @@ import os
 import signal
 
 os.environ["OPENCV_FFMPEG_LOGLEVEL"] = "-8"
+import statistics  # noqa: E402
 import time  # noqa: E402
 from datetime import datetime  # noqa: E402
 
@@ -71,6 +72,8 @@ class BufferMonitor:
         process_interval_frames: int = 30,
         detect_any_animal: bool = True,
         animal_classes: list[int] | None = None,
+        # Instrumentation settings
+        detection_summary_interval: int = 300,
         # Buffer settings
         buffer_seconds: int = 60,
         # Clip timing
@@ -107,6 +110,14 @@ class BufferMonitor:
         # Stream recovery config
         self.stream_recovery_threshold = stream_recovery_threshold
         self.stream_recovery_confirmation = stream_recovery_confirmation
+
+        # Detection-confidence summary instrumentation (022-E). One EVENT-level
+        # rolling summary of detection polls every detection_summary_interval
+        # seconds (0 disables). Data source for threshold tuning (ho-12+).
+        self.detection_summary_interval = detection_summary_interval
+        self._summary_poll_count = 0
+        self._summary_detected_confidences: list[float] = []
+        self._summary_window_start = time.time()
 
         # Stream capture (NO tee mode)
         self.capture = StreamCapture(
@@ -287,6 +298,14 @@ class BufferMonitor:
                     self._visit_peak_confidence, self._frame_peak_confidence
                 )
 
+            # Accumulate detection-confidence summary data (022-E)
+            if self.detection_summary_interval > 0:
+                self._summary_poll_count += 1
+                if falcon_detected:
+                    self._summary_detected_confidences.append(self._frame_peak_confidence)
+                if time.time() - self._summary_window_start >= self.detection_summary_interval:
+                    self._emit_detection_summary()
+
             # Startup confirmation logic (similar to arrival, but no telegram until confirmed)
             if self.startup_pending and self.startup_pending_start is not None:
                 self.startup_frame_count += 1
@@ -364,6 +383,38 @@ class BufferMonitor:
 
         except Exception as e:
             logger.error(f"❌ Error processing frame {frame_number}: {e}", exc_info=True)
+
+    def _emit_detection_summary(self) -> None:
+        """Emit the rolling detection-confidence summary and reset the window (022-E).
+
+        One EVENT-level line per interval with a stable, parseable field order:
+        poll count, detected count, detection ratio, and min/median/max
+        confidence across detected polls (``conf=n/a`` when nothing was
+        detected — the line still appears so gaps stay visible).
+        """
+        polls = self._summary_poll_count
+        confidences = self._summary_detected_confidences
+        detected = len(confidences)
+        ratio = (detected / polls * 100) if polls else 0.0
+
+        if detected:
+            conf_fields = (
+                f"conf min={min(confidences):.2f} "
+                f"median={statistics.median(confidences):.2f} "
+                f"max={max(confidences):.2f}"
+            )
+        else:
+            conf_fields = "conf=n/a"
+
+        logger.event(
+            f"📊 Detection summary ({self.detection_summary_interval}s): "
+            f"polls={polls} detected={detected} ratio={ratio:.1f}% {conf_fields}"
+        )
+
+        # Reset the accumulator for the next window
+        self._summary_poll_count = 0
+        self._summary_detected_confidences = []
+        self._summary_window_start = time.time()
 
     def _handle_event(
         self,
@@ -1082,6 +1133,7 @@ def main():
             process_interval_frames=config.get("frame_interval", 30),
             detect_any_animal=config.get("detect_any_animal", True),
             animal_classes=config.get("animal_classes"),
+            detection_summary_interval=config.get("detection_summary_interval", 300),
             buffer_seconds=config.get("buffer_seconds", 60),
             clip_arrival_before=config.get("clip_arrival_before", 15),
             clip_arrival_after=config.get("clip_arrival_after", 30),

--- a/src/kanyo/utils/config.py
+++ b/src/kanyo/utils/config.py
@@ -32,6 +32,7 @@ DEFAULTS: dict[str, Any] = {
     "frame_interval": 30,  # process every Nth frame (30 = 2fps at 60fps)
     "model_path": "models/yolov8n.pt",  # YOLOv8 weights
     "detect_any_animal": True,  # treat any animal as falcon
+    "detection_summary_interval": 300,  # seconds between confidence summaries (0 disables)
     "exit_timeout": 300,  # 5 min - seconds before falcon "left" during visit
     "animal_classes": [14, 15, 16, 17, 18, 19, 20, 21, 22, 23],  # COCO animal IDs
     "timezone": "+00:00",  # GMT offset (e.g., -05:00 for NY, +10:00 for Sydney)

--- a/tests/test_detection_summary.py
+++ b/tests/test_detection_summary.py
@@ -1,0 +1,159 @@
+"""Tests for 022-E: periodic rolling detection-confidence summary.
+
+One EVENT-level aggregate line per detection_summary_interval seconds with a
+stable field order — the data source for tuning detection thresholds.
+"""
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from kanyo.detection.buffer_monitor import BufferMonitor
+from kanyo.utils.logger import EVENT
+
+MONITOR_LOGGER = "kanyo.detection.buffer_monitor"
+
+
+def make_monitor(detection_summary_interval: int = 300):
+    """Return a BufferMonitor with all external dependencies mocked out."""
+    with (
+        patch("kanyo.detection.buffer_monitor.StreamCapture"),
+        patch("kanyo.detection.buffer_monitor.FalconDetector"),
+        patch("kanyo.detection.buffer_monitor.FrameBuffer"),
+        patch("kanyo.detection.buffer_monitor.VisitRecorder"),
+        patch("kanyo.detection.buffer_monitor.BufferClipManager"),
+        patch("kanyo.detection.buffer_monitor.EventStore"),
+        patch("kanyo.detection.buffer_monitor.FalconEventHandler"),
+        patch("kanyo.detection.buffer_monitor.FalconStateMachine"),
+        patch("kanyo.detection.buffer_monitor.ArrivalClipRecorder"),
+    ):
+        monitor = BufferMonitor(
+            stream_url="test",
+            detection_summary_interval=detection_summary_interval,
+        )
+    monitor.visit_recorder.is_recording = False
+    monitor.arrival_clip_recorder.is_recording.return_value = False
+    monitor.frame_buffer.add_frame.return_value = None
+    monitor.state_machine.update.return_value = []
+    return monitor
+
+
+def detection(conf: float):
+    return SimpleNamespace(confidence=conf)
+
+
+def make_frame():
+    frame = MagicMock()
+    frame.shape = (720, 1280, 3)
+    return frame
+
+
+def summary_lines(caplog):
+    return [r.message for r in caplog.records if "Detection summary" in r.message]
+
+
+class TestSummaryComputation:
+    def test_stats_over_known_sequence(self, caplog):
+        """min/median/max/ratio are computed over detected polls only."""
+        monitor = make_monitor()
+        monitor._summary_poll_count = 4
+        monitor._summary_detected_confidences = [0.4, 0.8, 0.6]
+
+        with caplog.at_level(EVENT, logger=MONITOR_LOGGER):
+            monitor._emit_detection_summary()
+
+        lines = summary_lines(caplog)
+        assert len(lines) == 1
+        assert "(300s):" in lines[0]
+        assert "polls=4 detected=3 ratio=75.0%" in lines[0]
+        assert "conf min=0.40 median=0.60 max=0.80" in lines[0]
+
+    def test_no_detections_emits_na_line(self, caplog):
+        """The line still appears with conf=n/a so gaps stay visible."""
+        monitor = make_monitor()
+        monitor._summary_poll_count = 10
+        monitor._summary_detected_confidences = []
+
+        with caplog.at_level(EVENT, logger=MONITOR_LOGGER):
+            monitor._emit_detection_summary()
+
+        lines = summary_lines(caplog)
+        assert len(lines) == 1
+        assert "polls=10 detected=0 ratio=0.0% conf=n/a" in lines[0]
+
+    def test_emission_resets_accumulator(self):
+        monitor = make_monitor()
+        monitor._summary_poll_count = 4
+        monitor._summary_detected_confidences = [0.4]
+
+        monitor._emit_detection_summary()
+
+        assert monitor._summary_poll_count == 0
+        assert monitor._summary_detected_confidences == []
+
+
+class TestSummaryCadence:
+    def test_emits_once_per_interval_and_resets_window(self, caplog):
+        """One line per elapsed interval; the next window starts fresh."""
+        import time as real_time
+
+        monitor = make_monitor(detection_summary_interval=300)
+        monitor.detector.detect_birds.side_effect = [
+            [detection(0.5)],  # poll 1 — window not elapsed, no emission
+            [],  # poll 2 — window forced elapsed, emission
+            [detection(0.9)],  # poll 3 — fresh window, no emission
+        ]
+        now = datetime(2026, 7, 1, 10, 0, 0)
+        frame = make_frame()
+
+        with (
+            patch("kanyo.detection.buffer_monitor.get_now_tz", return_value=now),
+            caplog.at_level(EVENT, logger=MONITOR_LOGGER),
+        ):
+            monitor.process_frame(frame, frame_number=0)
+            assert summary_lines(caplog) == []
+
+            # Force the window to have elapsed before the second poll
+            monitor._summary_window_start = real_time.time() - 301
+            monitor.process_frame(frame, frame_number=1)
+
+            monitor.process_frame(frame, frame_number=2)
+
+        lines = summary_lines(caplog)
+        assert len(lines) == 1
+        assert "polls=2 detected=1 ratio=50.0%" in lines[0]
+        assert "conf min=0.50 median=0.50 max=0.50" in lines[0]
+
+        # Third poll landed in the fresh window
+        assert monitor._summary_poll_count == 1
+        assert monitor._summary_detected_confidences == [0.9]
+        # Emission restarted the window at (roughly) emission time
+        assert real_time.time() - monitor._summary_window_start < 300
+
+    def test_interval_zero_disables_summary(self, caplog):
+        monitor = make_monitor(detection_summary_interval=0)
+        monitor.detector.detect_birds.return_value = [detection(0.5)]
+        now = datetime(2026, 7, 1, 10, 0, 0)
+        frame = make_frame()
+
+        with (
+            patch("kanyo.detection.buffer_monitor.get_now_tz", return_value=now),
+            caplog.at_level(EVENT, logger=MONITOR_LOGGER),
+        ):
+            for n in range(5):
+                monitor.process_frame(frame, frame_number=n)
+
+        assert summary_lines(caplog) == []
+        assert monitor._summary_poll_count == 0
+        assert monitor._summary_detected_confidences == []
+
+
+class TestSummaryConfig:
+    def test_default_in_config_defaults(self):
+        from kanyo.utils.config import DEFAULTS
+
+        assert DEFAULTS["detection_summary_interval"] == 300
+
+    def test_monitor_default_interval(self):
+        monitor = make_monitor()
+        assert monitor.detection_summary_interval == 300


### PR DESCRIPTION
## Diagnosis

Detection-poll confidence is only visible at DEBUG level, per frame. There is no aggregate view, so `detection_confidence` / `detection_confidence_ir` (and ho-12's `presence_sustain_confidence`) cannot be tuned from production data.

## Change

- `src/kanyo/detection/buffer_monitor.py`: per-poll accumulator in `process_frame` (poll count + max confidence of each detected poll); every `detection_summary_interval` seconds one EVENT-level line with stable field order:
  `📊 Detection summary (300s): polls=98 detected=41 ratio=41.8% conf min=0.31 median=0.52 max=0.87`
  When nothing was detected the line still appears with `detected=0 ratio=0.0% conf=n/a` so gaps stay visible. Accumulator resets after each emission; interval 0 disables. New `detection_summary_interval` constructor param wired through `main()`. The existing 5-minute DEBUG heartbeat is untouched.
- `src/kanyo/utils/config.py`: `detection_summary_interval: 300` added to `DEFAULTS`.
- `configs/config.template.yaml`: key documented in the file's established comment style.
- `tests/test_detection_summary.py` (new): min/median/max/ratio over a known sequence; n/a line for empty windows; accumulator reset; emission cadence honoring the interval; interval 0 emits nothing; config default.

## Verification

- black + isort applied to changed files; mypy src/ clean.
- pytest: 321 passed (7 new); only the 4 pre-existing environment-dependent failures already on main. No behavior change to detection or state handling.