### PR TITLE
022-C: Snapshot roosting-stop departure clip at first missed poll

### DIFF
--- a/src/kanyo/detection/buffer_clip_manager.py
+++ b/src/kanyo/detection/buffer_clip_manager.py
@@ -8,7 +8,7 @@ No tee or segment files required - simple and reliable.
 from __future__ import annotations
 
 import subprocess
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -293,6 +293,37 @@ class BufferClipManager:
             event_name,
         )
         return True
+
+    def extract_candidate_clip(
+        self,
+        start_time: datetime,
+        end_time: datetime,
+        clip_path: Path,
+    ) -> Future[str | None]:
+        """
+        Schedule extraction of a departure-candidate clip to an explicit path.
+
+        Used by the roosting-stop departure-candidate mechanism (022-C): the
+        caller names the target (a ``.mp4.tmp`` path) and holds the returned
+        future so it can later finalize (rename) or discard the file.
+
+        Args:
+            start_time: Clip start time
+            end_time: Clip end time
+            clip_path: Explicit output path (candidate ``.mp4.tmp``)
+
+        Returns:
+            Future resolving to the written path string, or None on failure
+        """
+        logger.event(f"📹 Snapshotting departure-candidate clip from buffer: {clip_path.name}")
+
+        return self._executor.submit(
+            self._extract_clip_from_buffer,
+            start_time,
+            end_time,
+            clip_path,
+            "departure-candidate",
+        )
 
     def _extract_clip_from_buffer(
         self,

--- a/src/kanyo/detection/buffer_monitor.py
+++ b/src/kanyo/detection/buffer_monitor.py
@@ -11,7 +11,9 @@ import signal
 os.environ["OPENCV_FFMPEG_LOGLEVEL"] = "-8"
 import statistics  # noqa: E402
 import time  # noqa: E402
-from datetime import datetime  # noqa: E402
+from concurrent.futures import Future  # noqa: E402
+from datetime import datetime, timedelta  # noqa: E402
+from pathlib import Path  # noqa: E402
 
 from kanyo.detection.buffer_clip_manager import BufferClipManager  # noqa: E402
 from kanyo.detection.capture import StreamCapture  # noqa: E402
@@ -239,6 +241,15 @@ class BufferMonitor:
         self.last_roosting_check: datetime | None = None
         self._roosting_visit_metadata: dict | None = None
 
+        # Roosting-stop departure-candidate clip (022-C). At the first missed
+        # roosting poll the departure window is still in the buffer, so a
+        # candidate clip is snapshotted to the final departure path with a
+        # .mp4.tmp suffix. DEPARTED finalizes it (rename); a re-confirming
+        # bird discards it. Candidate = (extraction future, tmp path, final
+        # path).
+        self._roosting_last_poll_detected = False
+        self._departure_candidate: tuple[Future[str | None], Path, Path] | None = None
+
         logger.info("BufferMonitor initialized (no tee mode)")
 
     def process_frame(self, frame_data, frame_number: int) -> None:
@@ -305,6 +316,28 @@ class BufferMonitor:
                     self._summary_detected_confidences.append(self._frame_peak_confidence)
                 if time.time() - self._summary_window_start >= self.detection_summary_interval:
                     self._emit_detection_summary()
+
+            # Roosting-stop departure-candidate snapshot/discard (022-C).
+            # Runs before the state machine update so state_machine
+            # .last_detection still refers to the last successful poll.
+            if self.roosting_mode_active and self.roosting_recording_mode == "stop":
+                if falcon_detected:
+                    if not self._roosting_last_poll_detected and self._departure_candidate:
+                        # Bird re-confirmed after a miss — the candidate was
+                        # not a departure. Discard it; a later first-miss
+                        # snapshots a fresh one.
+                        logger.event(
+                            "🦅 Roosting bird re-confirmed — discarding departure-candidate clip"
+                        )
+                        self._discard_departure_candidate()
+                    self._roosting_last_poll_detected = True
+                else:
+                    if self._roosting_last_poll_detected:
+                        # First missed poll — the departure window is still in
+                        # the buffer. Snapshot it now; DEPARTED (if it fires)
+                        # finalizes it, a re-confirmation discards it.
+                        self._snapshot_departure_candidate(now)
+                    self._roosting_last_poll_detected = False
 
             # Startup confirmation logic (similar to arrival, but no telegram until confirmed)
             if self.startup_pending and self.startup_pending_start is not None:
@@ -416,6 +449,107 @@ class BufferMonitor:
         self._summary_detected_confidences = []
         self._summary_window_start = time.time()
 
+    def _snapshot_departure_candidate(self, now: datetime) -> None:
+        """Snapshot a departure-candidate clip at the first missed roosting poll (022-C).
+
+        The actual departure lies between the last successful roosting poll
+        and this first miss — and right now that window is still in the
+        buffer (polls are roosting_detection_interval apart, well inside
+        buffer_seconds). The candidate covers
+        [last_detection − clip_departure_before, now] and is written to the
+        final departure path for last_detection with a .mp4.tmp suffix —
+        last_detection at snapshot time is exactly what becomes visit_end if
+        DEPARTED later fires, so the final name is already known.
+        """
+        last_detection = self.state_machine.last_detection
+        if last_detection is None:
+            logger.warning("Cannot snapshot departure candidate: no last_detection on hand")
+            return
+
+        # Any stale candidate should have been discarded on re-confirmation;
+        # be defensive so miss/re-confirm cycles never accumulate .tmp files.
+        if self._departure_candidate is not None:
+            self._discard_departure_candidate()
+
+        final_path = get_output_path(self.clips_dir, last_detection, "departure", "mp4")
+        tmp_path = final_path.with_suffix(".mp4.tmp")
+        start_time = last_detection - timedelta(seconds=self.clip_manager.clip_departure_before)
+
+        future = self.clip_manager.extract_candidate_clip(start_time, now, tmp_path)
+        self._departure_candidate = (future, tmp_path, final_path)
+
+    def _discard_departure_candidate(self) -> None:
+        """Discard an outstanding departure-candidate clip, deleting its .tmp file (022-C)."""
+        candidate = self._departure_candidate
+        self._departure_candidate = None
+        if candidate is None:
+            return
+
+        future, tmp_path, _ = candidate
+        future.cancel()
+        try:
+            # If extraction is still running, wait for it so the .tmp file is
+            # not recreated after we delete it.
+            future.result(timeout=30)
+        except Exception:
+            # Cancelled or extraction failed — either way only the file matters.
+            pass
+
+        try:
+            if tmp_path.exists():
+                tmp_path.unlink()
+                logger.debug(f"Deleted departure-candidate clip: {tmp_path.name}")
+        except OSError as e:
+            logger.warning(f"Could not delete departure-candidate clip {tmp_path.name}: {e}")
+
+    def _finalize_departure_candidate(self, event_time: datetime) -> bool:
+        """Finalize the departure-candidate clip on a roosting-stop DEPARTED (022-C).
+
+        Renames the candidate .mp4.tmp to its final .mp4 name, waiting on the
+        extraction future (bounded) if it is still running. With no candidate
+        on hand (e.g. process restarted mid-roost) falls back to the direct
+        buffer extraction, whose window is by construction usually already
+        evicted — the fallback is logged loudly and never fails the departure
+        handling.
+
+        Returns:
+            True if a departure clip was produced/scheduled, False otherwise.
+        """
+        candidate = self._departure_candidate
+        self._departure_candidate = None
+
+        if candidate is None:
+            logger.warning(
+                "No departure-candidate clip on hand — falling back to direct buffer "
+                "extraction; the clip window may already be evicted"
+            )
+            return self.clip_manager.create_clip_from_buffer(
+                event_time,
+                "departure",
+                before_seconds=self.clip_manager.clip_departure_before,
+                after_seconds=self.clip_manager.clip_departure_after,
+            )
+
+        future, tmp_path, final_path = candidate
+        try:
+            result = future.result(timeout=30)
+        except Exception as e:
+            logger.error(f"Departure-candidate extraction failed: {e}")
+            result = None
+
+        if result is None or not tmp_path.exists():
+            logger.warning("Departure-candidate clip missing — no departure clip for this visit")
+            return False
+
+        try:
+            tmp_path.rename(final_path)
+        except OSError as e:
+            logger.error(f"Could not finalize departure clip {tmp_path.name}: {e}")
+            return False
+
+        logger.event(f"✅ Departure clip finalized from candidate: {final_path.name}")
+        return True
+
     def _handle_event(
         self,
         event_type: FalconEvent,
@@ -476,13 +610,12 @@ class BufferMonitor:
 
             # Handle departure from roosting stop mode (visit recorder already stopped)
             if self.roosting_mode_active and self.roosting_recording_mode == "stop":
-                logger.event("🦅 DEPARTURE from roost — extracting departure clip from buffer")
-                departure_clip_scheduled = self.clip_manager.create_clip_from_buffer(
-                    event_time,
-                    "departure",
-                    before_seconds=self.clip_manager.clip_departure_before,
-                    after_seconds=self.clip_manager.clip_departure_after,
-                )
+                logger.event("🦅 DEPARTURE from roost — finalizing departure-candidate clip")
+                # Finalize the candidate snapshotted at the first missed poll
+                # (022-C). The direct buffer extraction this replaces could
+                # never work here: event_time is last_detection, which is
+                # ≥ exit_timeout in the past — always outside the buffer.
+                departure_clip_scheduled = self._finalize_departure_candidate(event_time)
                 if self._roosting_visit_metadata and "visit_start" in metadata:
                     visit_start_dt = metadata["visit_start"]
                     if isinstance(visit_start_dt, str):
@@ -521,6 +654,9 @@ class BufferMonitor:
                 self.roosting_mode_active = False
                 self.last_roosting_check = None
                 self._roosting_visit_metadata = None
+                # Roosting mode over — reset candidate poll tracking (022-C).
+                # The candidate itself was consumed by the finalize above.
+                self._roosting_last_poll_detected = False
                 return
 
             # Stop recording and create clips
@@ -603,6 +739,9 @@ class BufferMonitor:
                     )
                 self.roosting_mode_active = True
                 self.last_roosting_check = event_time
+                # Roosting starts on a detected poll — the candidate mechanism
+                # (022-C) begins from a "detected" state.
+                self._roosting_last_poll_detected = True
             else:
                 # continuous mode: recording continues uninterrupted
                 if self.visit_recorder.is_recording:
@@ -1076,6 +1215,10 @@ class BufferMonitor:
                 self.arrival_clip_recorder.rename_to_final()  # Sets _confirmed flag
                 self.arrival_clip_recorder.stop_recording(now)
                 logger.info("✅ Final arrival clip saved")
+
+            # Clean up an outstanding departure-candidate clip (022-C) —
+            # no orphan .tmp files across restarts.
+            self._discard_departure_candidate()
 
             # Shutdown clip manager
             self.clip_manager.shutdown()

--- a/tests/test_roosting_departure_candidate.py
+++ b/tests/test_roosting_departure_candidate.py
@@ -1,0 +1,242 @@
+"""Tests for 022-C: departure-candidate clip snapshot in roosting-stop mode.
+
+In roosting-stop mode DEPARTED fires with event_time = last_detection, which is
+>= exit_timeout in the past — always outside the 60s buffer, so the old direct
+buffer extraction failed silently every time. The candidate mechanism snapshots
+the departure window at the first missed roosting poll (while it is still in
+the buffer), finalizes it on DEPARTED, and discards it on re-confirmation.
+"""
+
+from concurrent.futures import Future
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from kanyo.detection.buffer_monitor import BufferMonitor
+from kanyo.detection.event_types import FalconEvent
+from kanyo.utils.output import get_output_path
+
+
+def make_monitor(clips_dir: str = "clips"):
+    """Return a roosting-stop BufferMonitor with external dependencies mocked out."""
+    with (
+        patch("kanyo.detection.buffer_monitor.StreamCapture"),
+        patch("kanyo.detection.buffer_monitor.FalconDetector"),
+        patch("kanyo.detection.buffer_monitor.FrameBuffer"),
+        patch("kanyo.detection.buffer_monitor.VisitRecorder"),
+        patch("kanyo.detection.buffer_monitor.BufferClipManager"),
+        patch("kanyo.detection.buffer_monitor.EventStore"),
+        patch("kanyo.detection.buffer_monitor.FalconEventHandler"),
+        patch("kanyo.detection.buffer_monitor.FalconStateMachine"),
+        patch("kanyo.detection.buffer_monitor.ArrivalClipRecorder"),
+    ):
+        monitor = BufferMonitor(
+            stream_url="test",
+            clips_dir=clips_dir,
+            full_config={
+                "roosting_recording_mode": "stop",
+                "roosting_detection_interval": 30,
+            },
+        )
+    monitor.visit_recorder.is_recording = False
+    monitor.arrival_clip_recorder.is_recording.return_value = False
+    monitor.frame_buffer.add_frame.return_value = None
+    monitor.state_machine.update.return_value = []
+    monitor.clip_manager.clip_departure_before = 30
+    monitor.clip_manager.clip_departure_after = 15
+    return monitor
+
+
+def detection(conf: float = 0.8):
+    return SimpleNamespace(confidence=conf)
+
+
+def make_frame():
+    frame = MagicMock()
+    frame.shape = (720, 1280, 3)
+    return frame
+
+
+def completed_future(result):
+    future: Future = Future()
+    future.set_result(result)
+    return future
+
+
+def run_poll(monitor, detections, now):
+    """Run one roosting poll through process_frame at the given time."""
+    monitor.detector.detect_birds.return_value = detections
+    # Ensure the roosting interval gate lets the poll through
+    monitor.last_roosting_check = now - timedelta(seconds=31)
+    with patch("kanyo.detection.buffer_monitor.get_now_tz", return_value=now):
+        monitor.process_frame(make_frame(), frame_number=1)
+
+
+class TestCandidateSnapshot:
+    def test_first_missed_poll_snapshots_candidate(self, tmp_path):
+        """detect → miss: candidate scheduled at the final departure path + .tmp."""
+        monitor = make_monitor(clips_dir=str(tmp_path))
+        monitor.roosting_mode_active = True
+        monitor._roosting_last_poll_detected = True
+
+        last_det = datetime(2026, 7, 1, 10, 0, 0)
+        now = datetime(2026, 7, 1, 10, 0, 30)
+        monitor.state_machine.last_detection = last_det
+        fake_future = completed_future(None)
+        monitor.clip_manager.extract_candidate_clip.return_value = fake_future
+
+        run_poll(monitor, [], now)
+
+        final_path = get_output_path(str(tmp_path), last_det, "departure", "mp4")
+        tmp_clip = final_path.with_suffix(".mp4.tmp")
+        monitor.clip_manager.extract_candidate_clip.assert_called_once_with(
+            last_det - timedelta(seconds=30), now, tmp_clip
+        )
+        assert monitor._departure_candidate == (fake_future, tmp_clip, final_path)
+        assert monitor._roosting_last_poll_detected is False
+
+    def test_second_missed_poll_does_not_resnapshot(self, tmp_path):
+        """Only the FIRST miss snapshots; consecutive misses leave it alone."""
+        monitor = make_monitor(clips_dir=str(tmp_path))
+        monitor.roosting_mode_active = True
+        monitor._roosting_last_poll_detected = True
+        monitor.state_machine.last_detection = datetime(2026, 7, 1, 10, 0, 0)
+        monitor.clip_manager.extract_candidate_clip.return_value = completed_future(None)
+
+        run_poll(monitor, [], datetime(2026, 7, 1, 10, 0, 30))
+        run_poll(monitor, [], datetime(2026, 7, 1, 10, 1, 0))
+
+        assert monitor.clip_manager.extract_candidate_clip.call_count == 1
+
+    def test_reconfirmation_discards_candidate(self, tmp_path):
+        """miss → re-detect: candidate .tmp deleted, state cleared."""
+        monitor = make_monitor(clips_dir=str(tmp_path))
+        monitor.roosting_mode_active = True
+        monitor._roosting_last_poll_detected = False
+
+        tmp_clip = tmp_path / "falcon_100000_000000_departure.mp4.tmp"
+        tmp_clip.write_bytes(b"fake video")
+        final_path = tmp_path / "falcon_100000_000000_departure.mp4"
+        monitor._departure_candidate = (
+            completed_future(str(tmp_clip)),
+            tmp_clip,
+            final_path,
+        )
+
+        run_poll(monitor, [detection()], datetime(2026, 7, 1, 10, 1, 0))
+
+        assert monitor._departure_candidate is None
+        assert not tmp_clip.exists()
+        assert monitor._roosting_last_poll_detected is True
+
+    def test_miss_reconfirm_cycles_leave_no_tmp_files(self, tmp_path):
+        """Repeated miss/re-confirm cycles never accumulate .tmp files."""
+        monitor = make_monitor(clips_dir=str(tmp_path))
+        monitor.roosting_mode_active = True
+        monitor._roosting_last_poll_detected = True
+
+        def fake_extract(start_time, end_time, clip_path):
+            clip_path.parent.mkdir(parents=True, exist_ok=True)
+            clip_path.write_bytes(b"fake video")
+            return completed_future(str(clip_path))
+
+        monitor.clip_manager.extract_candidate_clip.side_effect = fake_extract
+
+        base = datetime(2026, 7, 1, 10, 0, 0)
+        for cycle in range(3):
+            # Fresh last_detection each cycle so each candidate has its own path
+            monitor.state_machine.last_detection = base + timedelta(minutes=2 * cycle)
+            run_poll(monitor, [], base + timedelta(minutes=2 * cycle, seconds=30))
+            run_poll(monitor, [detection()], base + timedelta(minutes=2 * cycle + 1))
+
+        assert monitor._departure_candidate is None
+        assert list(tmp_path.rglob("*.tmp")) == []
+
+
+class TestCandidateFinalize:
+    def _departed(self, monitor, visit_start, last_det):
+        metadata = {"visit_start": visit_start, "visit_end": last_det}
+        monitor.roosting_mode_active = True
+        monitor._roosting_visit_metadata = {"visit_start": visit_start}
+        monitor.arrival_pending = False
+        monitor._handle_event(FalconEvent.DEPARTED, last_det, metadata)
+
+    def test_departed_finalizes_candidate(self, tmp_path):
+        """detect → miss → DEPARTED: .mp4.tmp renamed to .mp4; row carries the path."""
+        monitor = make_monitor(clips_dir=str(tmp_path))
+        visit_start = datetime(2026, 7, 1, 8, 0, 0)
+        last_det = datetime(2026, 7, 1, 10, 0, 0)
+
+        final_path = get_output_path(str(tmp_path), last_det, "departure", "mp4")
+        tmp_clip = final_path.with_suffix(".mp4.tmp")
+        tmp_clip.write_bytes(b"fake video")
+        monitor._departure_candidate = (
+            completed_future(str(tmp_clip)),
+            tmp_clip,
+            final_path,
+        )
+
+        self._departed(monitor, visit_start, last_det)
+
+        assert final_path.exists()
+        assert not tmp_clip.exists()
+        monitor.clip_manager.create_clip_from_buffer.assert_not_called()
+        # 022-A integration: the appended row carries the finalized clip path
+        visit = monitor.event_store.append.call_args[0][0]
+        assert visit.departure_clip_path == str(final_path)
+        assert monitor._departure_candidate is None
+        assert monitor.roosting_mode_active is False
+
+    def test_departed_without_candidate_falls_back(self, tmp_path):
+        """DEPARTED with no candidate: fallback buffer extraction, no exception."""
+        monitor = make_monitor(clips_dir=str(tmp_path))
+        visit_start = datetime(2026, 7, 1, 8, 0, 0)
+        last_det = datetime(2026, 7, 1, 10, 0, 0)
+        monitor.clip_manager.create_clip_from_buffer.return_value = False
+
+        self._departed(monitor, visit_start, last_det)
+
+        monitor.clip_manager.create_clip_from_buffer.assert_called_once_with(
+            last_det,
+            "departure",
+            before_seconds=30,
+            after_seconds=15,
+        )
+        # Visit row still appended, with no departure clip path
+        visit = monitor.event_store.append.call_args[0][0]
+        assert visit.departure_clip_path is None
+
+    def test_departed_with_failed_extraction_appends_row(self, tmp_path):
+        """Candidate extraction failed (no .tmp on disk): no clip, row still appended."""
+        monitor = make_monitor(clips_dir=str(tmp_path))
+        visit_start = datetime(2026, 7, 1, 8, 0, 0)
+        last_det = datetime(2026, 7, 1, 10, 0, 0)
+
+        final_path = get_output_path(str(tmp_path), last_det, "departure", "mp4")
+        tmp_clip = final_path.with_suffix(".mp4.tmp")  # never written
+        monitor._departure_candidate = (completed_future(None), tmp_clip, final_path)
+
+        self._departed(monitor, visit_start, last_det)
+
+        assert not final_path.exists()
+        visit = monitor.event_store.append.call_args[0][0]
+        assert visit.departure_clip_path is None
+
+
+class TestCandidateLifecycle:
+    def test_roosting_event_arms_poll_tracking(self):
+        """Entering roosting-stop mode starts from a detected-poll state."""
+        monitor = make_monitor()
+        monitor.visit_recorder.is_recording = True
+        monitor.visit_recorder.stop_recording.return_value = ("/fake/visit.mp4", {})
+
+        monitor._handle_event(FalconEvent.ROOSTING, datetime(2026, 7, 1, 9, 0, 0), {})
+
+        assert monitor._roosting_last_poll_detected is True
+        assert monitor._departure_candidate is None
+
+    def test_discard_with_no_candidate_is_noop(self):
+        monitor = make_monitor()
+        monitor._departure_candidate = None
+        monitor._discard_departure_candidate()  # must not raise
+        assert monitor._departure_candidate is None


### PR DESCRIPTION
## Diagnosis

In `roosting_recording_mode: stop`, DEPARTED fires with `event_time = last_detection`, which is by definition >= `exit_timeout` (90s) in the past. The handler called `create_clip_from_buffer` against a 60-second buffer — the requested window was always already evicted, so `extract_clip` logged "No frames found in range" and returned False. Roosting-stop departure clips were structurally impossible.

## Change

Snapshot at the first missed poll; finalize or discard later. The actual departure lies between the last successful roosting poll and the first missed one, and at the moment of the first miss that window is still in the buffer (polls 30s apart, buffer 60s).

- `src/kanyo/detection/buffer_monitor.py`:
  - New candidate bookkeeping: `_roosting_last_poll_detected` and `_departure_candidate` (future, tmp path, final path). Armed "detected" when roosting-stop mode starts; reset when roosting mode ends.
  - `process_frame` roosting-stop poll branch: first missed poll snapshots a candidate covering `[last_detection − clip_departure_before, now]` to the final departure path (`get_output_path(clips_dir, last_detection, "departure", "mp4")`) with a `.mp4.tmp` suffix; a re-confirming bird discards the candidate (tmp deleted); each later first-miss snapshots afresh.
  - Roosting-stop DEPARTED branch: `_finalize_departure_candidate` replaces the direct buffer extraction — waits on the extraction future (bounded 30s), renames `.mp4.tmp → .mp4`, and feeds the result into `departure_clip_path` (022-A). With no candidate on hand (e.g. restart mid-roost) it falls back to the old `create_clip_from_buffer` call with a loud warning and never fails the departure handling.
  - Shutdown (`run()` finally) discards an outstanding candidate — no orphan `.tmp` files.
- `src/kanyo/detection/buffer_clip_manager.py`: `extract_candidate_clip(start, end, path)` — schedules `_extract_clip_from_buffer` to an explicit path on the existing executor and returns the trackable future.
- `tests/test_roosting_departure_candidate.py` (new): snapshot at first miss with expected path/window; no re-snapshot on consecutive misses; discard on re-confirmation; repeated miss/re-confirm cycles leave no `.tmp` files; DEPARTED finalize (rename + row carries path); no-candidate fallback (no exception, row appended); failed-extraction path.

Continuous-mode departure behavior is untouched (existing `test_roosting_mode` tests still green — the roost-departure test now exercises the documented fallback). No state machine, timeout, or clip-timing changes.

## Verification

- black + isort applied to changed files; mypy src/ clean.
- pytest: 330 passed (9 new); only the 4 pre-existing environment-dependent failures already on main.