### PR TITLE
023-A: Worker-thread frame reader with timeout sentinel and read-time timestamps

### DIFF
--- a/configs/config.template.yaml
+++ b/configs/config.template.yaml
@@ -150,9 +150,19 @@ roosting_detection_interval: 30
 #   this many seconds and checks whether the bird is still present before
 #   resuming normal operation. Prevents a recovery attempt on a stream that
 #   immediately drops again.
+#
+# stream_read_timeout_s — Seconds without a frame from the stream reader
+#   thread before the monitor sees an explicit no-frame sentinel and starts
+#   outage handling (freeze-frame fill in active recordings, outage
+#   accounting). This is what makes a silently *blocked* read detectable —
+#   not just a failed one. Raise (e.g. 20) on streams that legitimately
+#   pause between frames; lower (e.g. 5) to react faster on reliable
+#   streams. Keep it below stream_recovery_threshold so short outages are
+#   seen in time to attempt recovery.
 
 stream_recovery_threshold: 30
 stream_recovery_confirmation: 10
+stream_read_timeout_s: 10.0
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/src/kanyo/detection/buffer_monitor.py
+++ b/src/kanyo/detection/buffer_monitor.py
@@ -91,6 +91,7 @@ class BufferMonitor:
         # Stream recovery settings
         stream_recovery_threshold: int = 30,
         stream_recovery_confirmation: int = 10,
+        stream_read_timeout_s: float = 10.0,
         # Notification settings
         notify_on_startup: bool = True,
         record_arrival_on_startup: bool = False,
@@ -121,10 +122,14 @@ class BufferMonitor:
         self._summary_detected_confidences: list[float] = []
         self._summary_window_start = time.time()
 
-        # Stream capture (NO tee mode)
+        # Stream capture (NO tee mode). Frames are stamped once, at read
+        # time, in the reader thread — in the stream's configured timezone
+        # so frame timestamps match every existing timestamp (ho-11).
         self.capture = StreamCapture(
             stream_url,
             use_tee=False,  # Key difference: no tee
+            read_timeout_s=stream_read_timeout_s,
+            now_fn=lambda: get_now_tz(self.full_config),
         )
 
         # Detector
@@ -1000,6 +1005,12 @@ class BufferMonitor:
                     logger.info("🛑 Graceful shutdown requested...")
                     break
 
+                # No-frame sentinel from the reader thread (ho-11). Full
+                # outage consumption (freeze-frame fill, outage accounting)
+                # lands in 023-B — until then the sentinel is skipped.
+                if frame is None:
+                    continue
+
                 frames_processed += 1
                 current_time = time.time()
 
@@ -1288,6 +1299,7 @@ def main():
             roosting_threshold=config.get("roosting_threshold", 1800),
             stream_recovery_threshold=config.get("stream_recovery_threshold", 30),
             stream_recovery_confirmation=config.get("stream_recovery_confirmation", 10),
+            stream_read_timeout_s=config.get("stream_read_timeout_s", 10.0),
             notify_on_startup=config.get("notify_on_startup", True),
             record_arrival_on_startup=config.get("record_arrival_on_startup", False),
             max_runtime_seconds=config.get("max_runtime_seconds"),

--- a/src/kanyo/detection/capture.py
+++ b/src/kanyo/detection/capture.py
@@ -7,10 +7,13 @@ with automatic reconnection support.
 
 from __future__ import annotations
 
+import queue
 import random
 import subprocess
+import threading
 import time
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Callable, Iterator
 
 import cv2
@@ -27,20 +30,42 @@ BACKOFF_MULTIPLIER = 2.0
 BACKOFF_JITTER_FRAC = 0.2
 MAX_DAILY_ATTEMPTS = 50  # hard ceiling per stream per 24h
 
+# Reader-thread constants (ho-11 / 023-A)
+FRAME_QUEUE_MAXSIZE = 30  # bounded queue between reader thread and consumer
+READER_JOIN_TIMEOUT_S = 5.0  # max wait for the reader thread on disconnect
+
 
 @dataclass
 class Frame:
-    """A captured video frame with metadata."""
+    """A captured video frame with metadata.
+
+    ``timestamp`` is assigned once, in the reader thread, the moment
+    ``cap.read()`` returns — it is the single time authority for everything
+    derived from this frame (ho-11).
+    """
 
     data: np.ndarray
     frame_number: int
     width: int
     height: int
+    timestamp: datetime
 
     @property
     def shape(self) -> tuple[int, int, int]:
         """Return (height, width, channels)."""
         return self.data.shape
+
+
+class _ReadFailure:
+    """Queue marker: the reader thread saw a failed read (``ret == False``).
+
+    Distinct from the ``None`` no-frame sentinel that ``frames()`` yields on
+    a read *timeout* — a read failure triggers the reconnect path, a timeout
+    surfaces a silent/blocked stream to the consumer.
+    """
+
+
+_READ_FAILURE = _ReadFailure()
 
 
 class StreamCapture:
@@ -58,6 +83,8 @@ class StreamCapture:
         reconnect_delay: float = 5.0,
         use_tee: bool = False,  # Deprecated, kept for compatibility
         on_connection_issue: Callable[[str], None] | None = None,
+        read_timeout_s: float = 10.0,
+        now_fn: Callable[[], datetime] | None = None,
     ):
         """
         Initialize stream capture.
@@ -68,13 +95,27 @@ class StreamCapture:
             reconnect_delay: Seconds to wait before reconnecting
             use_tee: DEPRECATED - ignored, kept for API compatibility
             on_connection_issue: Optional callback for admin notifications on connection issues
+            read_timeout_s: Seconds without a frame from the reader thread
+                before frames() yields a ``None`` no-frame sentinel
+            now_fn: Clock used to stamp frames at read time. Defaults to
+                UTC wall clock; the monitor injects the stream's configured
+                timezone so frame timestamps match every existing timestamp.
         """
         self.stream_url = stream_url
         self.max_height = max_height
         self.reconnect_delay = reconnect_delay
         self.on_connection_issue = on_connection_issue
+        self.read_timeout_s = read_timeout_s
+        self._now_fn: Callable[[], datetime] = now_fn or (lambda: datetime.now(timezone.utc))
         self._cap: cv2.VideoCapture | None = None
         self._frame_count = 0
+        # Reader thread state (ho-11): the worker reads frames off the
+        # stream and pushes them into a bounded queue; frames() consumes.
+        self._frame_queue: queue.Queue[Frame | _ReadFailure] = queue.Queue(
+            maxsize=FRAME_QUEUE_MAXSIZE
+        )
+        self._reader_thread: threading.Thread | None = None
+        self._stop_reader = threading.Event()
         self._ytdlp_fallback_used = False
         self.ytdlp_opts: dict = {}
         self._last_admin_notification_time: float = 0
@@ -217,11 +258,28 @@ class StreamCapture:
             return False
 
     def disconnect(self) -> None:
-        """Release the video capture."""
-        if self._cap is not None:
-            self._cap.release()
-            self._cap = None
+        """Stop the reader thread and release the video capture.
+
+        Order matters: the stop event is set first, then the capture is
+        released (which unblocks a reader stuck in ``cap.read()``), then the
+        thread is joined. No thread survives this call in normal operation.
+        """
+        self._stop_reader.set()
+
+        cap = self._cap
+        self._cap = None
+        if cap is not None:
+            cap.release()
             logger.debug("Disconnected from stream")
+
+        thread = self._reader_thread
+        if thread is not None and thread.is_alive():
+            thread.join(timeout=READER_JOIN_TIMEOUT_S)
+            if thread.is_alive():
+                # Daemon thread — it cannot block process exit, but a stuck
+                # ffmpeg read is worth a loud log (ho-08 precedent).
+                logger.warning("Reader thread did not stop within join timeout")
+        self._reader_thread = None
 
     def reconnect(self) -> bool:
         """Disconnect and reconnect. Backoff timing is owned by connect()."""
@@ -233,7 +291,9 @@ class StreamCapture:
         """
         Read a single frame from the stream.
 
-        Returns None if read fails (stream interrupted).
+        Returns None if read fails (stream interrupted). The frame's
+        timestamp is assigned here, the moment the read returns — under the
+        reader thread this is read time, the single time authority (ho-11).
         """
         if self._cap is None:
             return None
@@ -244,26 +304,94 @@ class StreamCapture:
 
         self._frame_count += 1
         h, w = data.shape[:2]
-        return Frame(data=data, frame_number=self._frame_count, width=w, height=h)
+        return Frame(
+            data=data,
+            frame_number=self._frame_count,
+            width=w,
+            height=h,
+            timestamp=self._now_fn(),
+        )
 
-    def frames(self, skip: int = 0) -> Iterator[Frame]:
+    def _enqueue(self, item: Frame | _ReadFailure) -> None:
+        """Push an item onto the bounded frame queue, dropping the oldest when full.
+
+        A stalled consumer must see fresh frames, not stale ones.
+        """
+        while True:
+            try:
+                self._frame_queue.put_nowait(item)
+                return
+            except queue.Full:
+                try:
+                    self._frame_queue.get_nowait()
+                except queue.Empty:
+                    pass
+
+    def _reader_loop(self) -> None:
+        """Worker thread body: read frames and push them into the queue.
+
+        On read failure a distinct marker is pushed and the loop exits —
+        reconnection decisions stay on the consumer side of the queue, and
+        the thread is restarted after a successful reconnect.
+        """
+        while not self._stop_reader.is_set():
+            try:
+                frame = self.read_frame()
+            except Exception as e:
+                # A dying capture handle (e.g. released mid-read during
+                # disconnect) reads as a failure, never a crash.
+                logger.error(f"Reader thread error: {e}")
+                frame = None
+
+            if self._stop_reader.is_set():
+                break
+
+            if frame is None:
+                self._enqueue(_READ_FAILURE)
+                break
+
+            self._enqueue(frame)
+
+    def _start_reader(self) -> None:
+        """Start the reader thread if it is not already running."""
+        if self._reader_thread is not None and self._reader_thread.is_alive():
+            return
+
+        # Drain leftovers from a previous connection so the consumer never
+        # sees stale frames or failure markers across a reconnect.
+        while True:
+            try:
+                self._frame_queue.get_nowait()
+            except queue.Empty:
+                break
+
+        self._stop_reader.clear()
+        self._reader_thread = threading.Thread(
+            target=self._reader_loop, name="stream-reader", daemon=True
+        )
+        self._reader_thread.start()
+
+    def frames(self, skip: int = 0) -> Iterator[Frame | None]:
         """
         Iterate over frames from the stream.
 
         Args:
             skip: Process every Nth frame (0 = all frames)
 
-        Yields Frame objects. Handles reconnection automatically.
-        All retry timing is owned by connect() — this method does not sleep.
+        Yields Frame objects, or ``None`` when no frame arrived within
+        ``read_timeout_s`` — the explicit no-frame sentinel (ho-11). A
+        blocked ``cv2.read()`` is just a quiet queue, and the timeout sees
+        it. Handles reconnection automatically; all retry timing is owned by
+        connect() — this method does not sleep.
         """
         if not self.connect():
             raise RuntimeError("Failed to connect to stream")
+        self._start_reader()
 
+        needs_reconnect = False
         try:
             while True:
-                frame = self.read_frame()
-
-                if frame is None:
+                if needs_reconnect:
                     # Send admin alert (throttled to once per hour)
                     if (
                         self.on_connection_issue
@@ -274,7 +402,10 @@ class StreamCapture:
                         self._outage_alert_sent = True
 
                     if not self.reconnect():
-                        continue  # reconnect() sleeps via connect() backoff
+                        # reconnect() slept via connect() backoff — surface
+                        # the ongoing outage to the consumer and retry.
+                        yield None
+                        continue
 
                     logger.info("✅ Reconnected successfully!")
                     # Only send "reconnected" when a matching "lost" alert was
@@ -283,13 +414,28 @@ class StreamCapture:
                     if self.on_connection_issue and self._outage_alert_sent:
                         self.on_connection_issue("Stream reconnected")
                         self._outage_alert_sent = False
+
+                    self._start_reader()
+                    needs_reconnect = False
+                    continue
+
+                try:
+                    item = self._frame_queue.get(timeout=self.read_timeout_s)
+                except queue.Empty:
+                    # No frame within the timeout — covers a *blocked* read,
+                    # not just a failed one. Explicit no-frame sentinel.
+                    yield None
+                    continue
+
+                if isinstance(item, _ReadFailure):
+                    needs_reconnect = True
                     continue
 
                 # Skip frames if requested
-                if skip > 0 and frame.frame_number % skip != 0:
+                if skip > 0 and item.frame_number % skip != 0:
                     continue
 
-                yield frame
+                yield item
 
         finally:
             self.disconnect()

--- a/src/kanyo/utils/config.py
+++ b/src/kanyo/utils/config.py
@@ -33,6 +33,7 @@ DEFAULTS: dict[str, Any] = {
     "model_path": "models/yolov8n.pt",  # YOLOv8 weights
     "detect_any_animal": True,  # treat any animal as falcon
     "detection_summary_interval": 300,  # seconds between confidence summaries (0 disables)
+    "stream_read_timeout_s": 10.0,  # seconds without a frame before the no-frame sentinel
     "exit_timeout": 300,  # 5 min - seconds before falcon "left" during visit
     "animal_classes": [14, 15, 16, 17, 18, 19, 20, 21, 22, 23],  # COCO animal IDs
     "timezone": "+00:00",  # GMT offset (e.g., -05:00 for NY, +10:00 for Sydney)
@@ -274,6 +275,11 @@ def _validate(cfg: dict[str, Any]) -> None:
             f"short_visit_threshold ({short_visit_threshold}s) is too short. "
             f"Minimum recommended value is 60 seconds."
         )
+
+    # stream_read_timeout_s sanity (ho-11)
+    read_timeout = cfg.get("stream_read_timeout_s", 10.0)
+    if not isinstance(read_timeout, (int, float)) or read_timeout <= 0:
+        raise ValueError("stream_read_timeout_s must be a positive number of seconds")
 
     # frame_interval sanity
     frame_interval = cfg.get("frame_interval", 3)

--- a/tests/test_connection_notifications.py
+++ b/tests/test_connection_notifications.py
@@ -117,24 +117,19 @@ class TestConnectionNotifications:
         # Should not raise error
         assert cap.on_connection_issue is None
 
-        # System should handle None callback gracefully - use counter to break loop
-        call_count = 0
-
-        def read_frame_then_exit():
-            nonlocal call_count
-            call_count += 1
-            if call_count > 2:
-                raise KeyboardInterrupt("Exit test")
-            return None
+        # A read failure followed by a good frame: the failure marker runs
+        # the reconnect path with no callback set, then the frame is yielded.
+        good_frame = MagicMock()
+        good_frame.frame_number = 1
 
         with patch.object(cap, "connect", return_value=True):
-            with patch.object(cap, "read_frame", side_effect=read_frame_then_exit):
-                with patch("kanyo.detection.capture.time.sleep"):
+            with patch.object(cap, "reconnect", return_value=True):
+                with patch.object(cap, "read_frame", side_effect=[None, good_frame]):
                     gen = cap.frames()
-                    try:
-                        next(gen)
-                    except KeyboardInterrupt:
-                        pass  # Expected exit
+                    frame = next(gen)
+                    gen.close()
+
+        assert frame is good_frame
 
     def test_exponential_backoff_implemented(self):
         """Connection retries should use exponential backoff."""

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -144,12 +144,14 @@ class TestFrame:
         from kanyo.detection.capture import Frame
 
         data = np.zeros((480, 640, 3), dtype=np.uint8)
-        frame = Frame(data=data, frame_number=1, width=640, height=480)
+        stamp = datetime.now()
+        frame = Frame(data=data, frame_number=1, width=640, height=480, timestamp=stamp)
 
         assert frame.frame_number == 1
         assert frame.width == 640
         assert frame.height == 480
         assert frame.shape == (480, 640, 3)
+        assert frame.timestamp == stamp
 
 
 class TestStreamCapture:

--- a/tests/test_stream_reader_thread.py
+++ b/tests/test_stream_reader_thread.py
@@ -1,0 +1,361 @@
+"""Tests for the worker-thread frame reader with timeout sentinel (ho-11 / 023-A).
+
+A scriptable fake cv2.VideoCapture drives the reader thread through frames,
+blocked reads, silence, and read failures. All waits are short polling loops
+bounded by the fake's ``release()`` — no sleep-based flakiness, no deadlocks.
+"""
+
+import queue
+import threading
+import time
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import numpy as np
+
+from kanyo.detection.capture import Frame, StreamCapture
+
+# Non-YouTube URL: connect() uses it directly, no yt-dlp subprocess involved.
+STREAM_URL = "http://example.com/test-stream.mp4"
+
+# Short read timeout so sentinel tests run fast; generous enough to be
+# deterministic (the worker pushes frames within microseconds).
+READ_TIMEOUT_S = 0.05
+
+
+def make_frame_data(value: int = 0) -> np.ndarray:
+    """A tiny distinguishable BGR frame."""
+    return np.full((4, 4, 3), value, dtype=np.uint8)
+
+
+class FakeVideoCapture:
+    """Scriptable stand-in for cv2.VideoCapture.
+
+    Script items:
+    - ``np.ndarray`` — returned as a successful read
+    - ``"fail"`` — read returns (False, None), like a broken stream
+    - ``threading.Event`` — read blocks until the event is set (a stalled
+      stream whose read never returns)
+
+    An exhausted script blocks forever (live-stream silence). ``release()``
+    unblocks any waiting read and makes it return failure — mirroring how a
+    released cv2 capture behaves.
+    """
+
+    def __init__(self, script: list) -> None:
+        self._script = list(script)
+        self._lock = threading.Lock()
+        self.released = False
+
+    def isOpened(self) -> bool:
+        return not self.released
+
+    def read(self):
+        while True:
+            if self.released:
+                return False, None
+
+            with self._lock:
+                item = self._script[0] if self._script else None
+
+            if item is None:
+                # Script exhausted — silent stream, block until released
+                time.sleep(0.005)
+                continue
+
+            if isinstance(item, threading.Event):
+                if not item.is_set():
+                    time.sleep(0.005)
+                    continue
+                with self._lock:
+                    self._script.pop(0)
+                continue
+
+            with self._lock:
+                self._script.pop(0)
+
+            if isinstance(item, str) and item == "fail":
+                return False, None
+            return True, item
+
+    def release(self) -> None:
+        self.released = True
+
+
+def reader_threads() -> list[threading.Thread]:
+    """All live stream-reader threads."""
+    return [t for t in threading.enumerate() if t.name == "stream-reader" and t.is_alive()]
+
+
+def next_real_frame(gen, max_sentinels: int = 200) -> Frame:
+    """Advance the generator past None sentinels to the next real frame."""
+    for _ in range(max_sentinels):
+        item = next(gen)
+        if item is not None:
+            return item
+    raise AssertionError("No real frame within sentinel budget")
+
+
+class TestNoFrameSentinel:
+    """frames() yields None when no frame arrives within read_timeout_s."""
+
+    def test_silence_yields_none_sentinel(self):
+        """A source that stops returning frames produces None sentinels."""
+        fake = FakeVideoCapture([make_frame_data(1), make_frame_data(2)])
+        capture = StreamCapture(STREAM_URL, read_timeout_s=READ_TIMEOUT_S)
+
+        with patch("kanyo.detection.capture.cv2.VideoCapture", return_value=fake):
+            gen = capture.frames()
+            f1 = next(gen)
+            f2 = next(gen)
+            sentinel = next(gen)
+            gen.close()
+
+        assert isinstance(f1, Frame) and f1.frame_number == 1
+        assert isinstance(f2, Frame) and f2.frame_number == 2
+        assert sentinel is None
+
+    def test_blocked_read_yields_none_sentinel(self):
+        """A read that BLOCKS (not merely fails) still surfaces as a sentinel.
+
+        This is the 021-F gap: a blocked cv2.read() froze the whole pipeline
+        silently. With the reader thread, a blocked read is just a quiet
+        queue and the consumer timeout sees it.
+        """
+        blocker = threading.Event()  # never set: read blocks indefinitely
+        fake = FakeVideoCapture([make_frame_data(1), blocker])
+        capture = StreamCapture(STREAM_URL, read_timeout_s=READ_TIMEOUT_S)
+
+        with patch("kanyo.detection.capture.cv2.VideoCapture", return_value=fake):
+            gen = capture.frames()
+            f1 = next(gen)
+            sentinel = next(gen)
+            gen.close()  # disconnect() releases the fake, unblocking the read
+
+        assert isinstance(f1, Frame)
+        assert sentinel is None
+        assert reader_threads() == []
+
+    def test_frames_resume_after_stall(self):
+        """When a stalled read unblocks, real frames flow again."""
+        stall = threading.Event()
+        fake = FakeVideoCapture([make_frame_data(1), stall, make_frame_data(2)])
+        capture = StreamCapture(STREAM_URL, read_timeout_s=READ_TIMEOUT_S)
+
+        with patch("kanyo.detection.capture.cv2.VideoCapture", return_value=fake):
+            gen = capture.frames()
+            f1 = next(gen)
+            sentinel = next(gen)
+            stall.set()
+            f2 = next_real_frame(gen)
+            gen.close()
+
+        assert isinstance(f1, Frame) and f1.frame_number == 1
+        assert sentinel is None
+        assert isinstance(f2, Frame) and f2.frame_number == 2
+
+
+class TestReadFailureReconnect:
+    """ret == False runs the existing lost-alert + reconnect path."""
+
+    def test_read_failure_reconnects_and_resumes(self):
+        """A failed read triggers one reconnect; frames resume on the new capture."""
+        fake1 = FakeVideoCapture([make_frame_data(1), "fail"])
+        fake2 = FakeVideoCapture([make_frame_data(2)])
+        messages: list[str] = []
+
+        capture = StreamCapture(
+            STREAM_URL,
+            read_timeout_s=READ_TIMEOUT_S,
+            on_connection_issue=messages.append,
+        )
+        capture._last_admin_notification_time = 0  # outside the 1/hour throttle
+
+        with patch("kanyo.detection.capture.cv2.VideoCapture", side_effect=[fake1, fake2]):
+            gen = capture.frames()
+            f1 = next(gen)
+            f2 = next_real_frame(gen)
+            gen.close()
+
+        assert isinstance(f1, Frame) and f1.frame_number == 1
+        # Frame numbering continues across the reconnect
+        assert isinstance(f2, Frame) and f2.frame_number == 2
+        assert fake1.released is True
+        # Paired alerts: one lost, one reconnected (022-D gating intact)
+        assert len(messages) == 2
+        assert "connection lost" in messages[0].lower()
+        assert "reconnected" in messages[1].lower()
+        # Successful reconnect resets backoff state
+        assert capture._consecutive_failures == 0
+
+    def test_failed_reconnect_yields_sentinel_and_retries(self):
+        """While reconnection fails, the consumer sees sentinels, then frames
+        once a connection succeeds. Backoff stays inside connect()."""
+        fake1 = FakeVideoCapture(["fail"])
+        fake_closed = FakeVideoCapture([])
+        fake_closed.released = True  # isOpened() False -> connect() fails
+        fake2 = FakeVideoCapture([make_frame_data(7)])
+
+        capture = StreamCapture(STREAM_URL, read_timeout_s=READ_TIMEOUT_S)
+
+        with patch(
+            "kanyo.detection.capture.cv2.VideoCapture",
+            side_effect=[fake1, fake_closed, fake2],
+        ):
+            with patch("kanyo.detection.capture.time.sleep") as mock_sleep:
+                gen = capture.frames()
+                sentinel = next(gen)  # read failure -> reconnect fails -> sentinel
+                frame = next_real_frame(gen)  # second reconnect attempt succeeds
+                gen.close()
+
+        assert sentinel is None
+        assert isinstance(frame, Frame)
+        # The failed connect slept its backoff (connect() owns retry timing)
+        assert mock_sleep.called
+        assert capture._consecutive_failures == 0
+
+
+class TestReadTimeTimestamps:
+    """Frame.timestamp comes from the injected clock, at read time."""
+
+    def test_timestamps_come_from_injected_now_fn(self):
+        """Yielded frames carry the injected clock's stamps in read order."""
+        t0 = datetime(2026, 7, 16, 12, 0, 0, tzinfo=timezone.utc)
+        stamps = [t0, t0 + timedelta(seconds=1), t0 + timedelta(seconds=2)]
+        clock = iter(stamps)
+
+        fake = FakeVideoCapture([make_frame_data(i) for i in range(3)])
+        capture = StreamCapture(
+            STREAM_URL,
+            read_timeout_s=READ_TIMEOUT_S,
+            now_fn=lambda: next(clock),
+        )
+
+        with patch("kanyo.detection.capture.cv2.VideoCapture", return_value=fake):
+            gen = capture.frames()
+            frames = [next(gen) for _ in range(3)]
+            gen.close()
+
+        assert [f.timestamp for f in frames] == stamps
+
+    def test_timestamps_at_read_cadence_not_consumer_cadence(self):
+        """A slow consumer still sees read-time stamps: the reader stamps all
+        frames as it reads them into the queue, before the consumer drains
+        them. This is the anti-burst-stamping property."""
+        t0 = datetime(2026, 7, 16, 12, 0, 0, tzinfo=timezone.utc)
+        read_times: list[datetime] = []
+
+        def clock() -> datetime:
+            stamp = t0 + timedelta(seconds=len(read_times))
+            read_times.append(stamp)
+            return stamp
+
+        fake = FakeVideoCapture([make_frame_data(i) for i in range(3)])
+        capture = StreamCapture(STREAM_URL, read_timeout_s=1.0, now_fn=clock)
+
+        with patch("kanyo.detection.capture.cv2.VideoCapture", return_value=fake):
+            gen = capture.frames()
+            first = next(gen)
+            # Wait until the reader has stamped ALL frames (they queue up
+            # while the consumer sits idle — a simulated pipeline stall).
+            deadline = time.time() + 5.0
+            while len(read_times) < 3 and time.time() < deadline:
+                time.sleep(0.005)
+            drained = [next(gen) for _ in range(2)]
+            gen.close()
+
+        stamps = [first.timestamp] + [f.timestamp for f in drained]
+        # Monotonic 1s spacing from the reader clock, not near-identical
+        # consumer-time stamps.
+        assert stamps == [t0 + timedelta(seconds=i) for i in range(3)]
+
+    def test_default_clock_is_utc(self):
+        """Without an injected clock, frames are stamped with UTC wall time."""
+        fake = FakeVideoCapture([make_frame_data(1)])
+        capture = StreamCapture(STREAM_URL, read_timeout_s=READ_TIMEOUT_S)
+
+        with patch("kanyo.detection.capture.cv2.VideoCapture", return_value=fake):
+            gen = capture.frames()
+            frame = next(gen)
+            gen.close()
+
+        assert frame.timestamp.tzinfo == timezone.utc
+
+
+class TestThreadLifecycle:
+    """The reader thread never leaks across disconnects or reconnect cycles."""
+
+    def test_disconnect_stops_reader_thread(self):
+        fake = FakeVideoCapture([make_frame_data(1)])
+        capture = StreamCapture(STREAM_URL, read_timeout_s=READ_TIMEOUT_S)
+
+        with patch("kanyo.detection.capture.cv2.VideoCapture", return_value=fake):
+            assert capture.connect() is True
+            capture._start_reader()
+            assert reader_threads() != []
+            capture.disconnect()
+
+        assert reader_threads() == []
+        assert capture._reader_thread is None
+
+    def test_repeated_cycles_accumulate_no_threads(self):
+        """connect/disconnect cycles never accumulate reader threads."""
+        capture = StreamCapture(STREAM_URL, read_timeout_s=READ_TIMEOUT_S)
+
+        for i in range(3):
+            fake = FakeVideoCapture([make_frame_data(i)])
+            with patch("kanyo.detection.capture.cv2.VideoCapture", return_value=fake):
+                assert capture.connect() is True
+                capture._start_reader()
+                assert len(reader_threads()) == 1
+                capture.disconnect()
+            assert reader_threads() == []
+
+    def test_generator_close_stops_reader_thread(self):
+        """Closing the frames() generator disconnects and joins the reader."""
+        fake = FakeVideoCapture([make_frame_data(1)])
+        capture = StreamCapture(STREAM_URL, read_timeout_s=READ_TIMEOUT_S)
+
+        with patch("kanyo.detection.capture.cv2.VideoCapture", return_value=fake):
+            gen = capture.frames()
+            next(gen)
+            assert reader_threads() != []
+            gen.close()
+
+        assert reader_threads() == []
+
+
+class TestBoundedQueue:
+    """The reader queue is bounded and drops the oldest item when full."""
+
+    def test_enqueue_drops_oldest_when_full(self):
+        capture = StreamCapture(STREAM_URL)
+        capture._frame_queue = queue.Queue(maxsize=2)
+
+        stamp = datetime.now(timezone.utc)
+
+        def frame(n: int) -> Frame:
+            return Frame(
+                data=make_frame_data(n), frame_number=n, width=4, height=4, timestamp=stamp
+            )
+
+        capture._enqueue(frame(1))
+        capture._enqueue(frame(2))
+        capture._enqueue(frame(3))  # full: drops frame 1
+
+        remaining = [capture._frame_queue.get_nowait().frame_number for _ in range(2)]
+        assert remaining == [2, 3]
+        assert capture._frame_queue.empty()
+
+    def test_skip_logic_preserved(self):
+        """skip=N still yields only every Nth frame by frame_number."""
+        fake = FakeVideoCapture([make_frame_data(i) for i in range(4)])
+        capture = StreamCapture(STREAM_URL, read_timeout_s=READ_TIMEOUT_S)
+
+        with patch("kanyo.detection.capture.cv2.VideoCapture", return_value=fake):
+            gen = capture.frames(skip=2)
+            f_a = next(gen)
+            f_b = next(gen)
+            gen.close()
+
+        assert (f_a.frame_number, f_b.frame_number) == (2, 4)


### PR DESCRIPTION
## Summary

Capture-side half of ho-11 (executes 021-F, option A — worker thread + queue). A blocked `cv2.VideoCapture.read()` is no longer silently freezing the pipeline: frame reading moves into a stoppable worker thread inside `StreamCapture`, pushing into a bounded queue (drop-oldest, maxsize 30). `frames()` consumes with `queue.get(timeout=stream_read_timeout_s)` and yields an explicit `None` no-frame sentinel on timeout — covering blocked reads, not just failed ones.

- `Frame` gains `timestamp`, assigned once, in the reader thread, the moment the read returns, via an injectable clock (`now_fn`). `BufferMonitor` injects `get_now_tz` over the stream's configured timezone — the single time authority downstream consumers switch to in 023-B.
- Read failures (`ret == False`) push a distinct marker; the consumer runs the existing lost-alert throttle + `reconnect()` path unchanged (022-D pairing intact, `connect()` owns all retry timing) and restarts the worker on success. Failed reconnect attempts surface as sentinels between backoffs.
- `disconnect()` stops and joins the worker (stop event first, then capture release to unblock a stuck read). Repeated connect/disconnect cycles accumulate no threads.
- New config key `stream_read_timeout_s` (default 10.0): `DEFAULTS`, validation, `main()` wiring, and `config.template.yaml` docs.
- `BufferMonitor.run()` skips the sentinel for now; full outage consumption (freeze-frame fill, outage accounting) is 023-B.

## Deviations from spec

- `run()` gains a minimal `if frame is None: continue` guard — required to keep `mypy src/` clean now that `frames()` yields `Frame | None`; 023-B replaces it with real sentinel handling.
- `test_no_callback_if_not_provided` rewritten: it drove `frames()` by raising `KeyboardInterrupt` from `read_frame`, which now executes on the worker thread; the new version exercises the same no-callback reconnect path deterministically.

## Testing

- New `tests/test_stream_reader_thread.py`: scriptable fake `cv2.VideoCapture` drives frames → silence, blocked reads, read failure → reconnect → resume, injected-clock read-time timestamps (anti-burst-stamping), thread lifecycle across cycles, drop-oldest queue, skip logic.
- `black`/`isort` applied, `mypy src/` clean, 343 passed — only the 4 pre-existing failures on main (`test_detect_on_blank_frame`, 3 `TestShowContext`).