### PR TITLE
023-B: Consume no-frame sentinel; frame.timestamp becomes the time authority

### DIFF
--- a/src/kanyo/detection/buffer_monitor.py
+++ b/src/kanyo/detection/buffer_monitor.py
@@ -227,6 +227,17 @@ class BufferMonitor:
         # inflated by the confirmation window length. See 021-J.
         self.recovery_latest_detection: datetime | None = None
 
+        # Outage tracking driven by the no-frame sentinel from capture
+        # (ho-11 / 023-B). The sentinel is the ONLY outage signal — the old
+        # wall-clock gap heuristic was blind to a blocked read and
+        # false-positived on slow processing. Duration is measured from the
+        # last real frame's read-time stamp to the first frame after the
+        # outage, matching the old gap semantics with trustworthy times.
+        self.stream_read_timeout_s = stream_read_timeout_s
+        self._outage_start: datetime | None = None
+        self._outage_sentinel_count = 0
+        self._last_frame_timestamp: datetime | None = None
+
         # Load arrival confirmation config
         self.arrival_confirmation_seconds = (
             full_config.get("arrival_confirmation_seconds", 10) if full_config else 10
@@ -257,17 +268,21 @@ class BufferMonitor:
 
         logger.info("BufferMonitor initialized (no tee mode)")
 
-    def process_frame(self, frame_data, frame_number: int) -> None:
+    def process_frame(self, frame_data, frame_number: int, timestamp: datetime) -> None:
         """Process a single frame for falcon detection.
 
         Args:
             frame_data: Frame image data
             frame_number: Frame sequence number
+            timestamp: The frame's read-time stamp — the single time
+                authority for everything derived from this frame (ho-11).
+                Frames that queued during a stall carry the times they were
+                actually read, so burst-stamping cannot occur here.
         """
         try:
-            now = get_now_tz(self.full_config)
+            now = timestamp
 
-            # Always add frame to buffer (use real time, not adjusted)
+            # Always add frame to buffer (read time, not processing time)
             self.frame_buffer.add_frame(frame_data, now, frame_number)
 
             # Store frame size for recorder initialization
@@ -356,10 +371,10 @@ class BufferMonitor:
 
                     if ratio >= self.arrival_confirmation_ratio:
                         # SUCCESS - confirm startup presence
-                        self._confirm_startup_presence()
+                        self._confirm_startup_presence(now)
                     else:
                         # FAILURE - not enough detections
-                        self._cancel_startup_presence(ratio)
+                        self._cancel_startup_presence(ratio, now)
 
             # Arrival confirmation logic
             if self.arrival_pending and self.arrival_pending_start is not None:
@@ -376,7 +391,7 @@ class BufferMonitor:
                         self._confirm_arrival()
                     else:
                         # FAILURE
-                        self._cancel_arrival(ratio)
+                        self._cancel_arrival(ratio, now)
 
             # Recovery confirmation logic (after stream outage)
             if self.recovery_pending and self.recovery_pending_start is not None:
@@ -391,10 +406,10 @@ class BufferMonitor:
 
                     if ratio >= self.arrival_confirmation_ratio:
                         # SUCCESS - bird still present
-                        self._confirm_recovery()
+                        self._confirm_recovery(now)
                     else:
                         # FAILURE - bird left during outage
-                        self._cancel_recovery(ratio)
+                        self._cancel_recovery(ratio, now)
 
             # Debug logging for detection tracking
             if falcon_detected:
@@ -606,7 +621,7 @@ class BufferMonitor:
             if self.arrival_pending:
                 # Bird left before confirmation - treat as failed confirmation
                 ratio = self.arrival_detection_count / max(self.arrival_frame_count, 1)
-                self._cancel_arrival(ratio)
+                self._cancel_arrival(ratio, event_time)
                 return  # Do not process departure normally
 
             # Stop arrival clip if still active (short visit may not have hit its time limit)
@@ -780,8 +795,14 @@ class BufferMonitor:
         self.arrival_detection_count = 0
         self.arrival_frame_count = 0
 
-    def _cancel_arrival(self, ratio: float) -> None:
-        """Cancel arrival - insufficient detections or early departure."""
+    def _cancel_arrival(self, ratio: float, now: datetime) -> None:
+        """Cancel arrival - insufficient detections or early departure.
+
+        Args:
+            ratio: Detection ratio that failed the confirmation threshold
+            now: The driving timestamp (frame read time or event time) —
+                no re-stamping at processing time (ho-11).
+        """
         logger.warning(
             f"⚠️  ARRIVAL CANCELLED - detection ratio: {ratio:.1%} "
             f"({self.arrival_detection_count}/{self.arrival_frame_count} frames, "
@@ -793,7 +814,6 @@ class BufferMonitor:
         visit_tmp = self.visit_recorder.get_temp_path()
 
         # Stop recordings WITHOUT renaming (keeps .tmp extension)
-        now = get_now_tz(self.full_config)
         self.arrival_clip_recorder.stop_recording(now)
         self.visit_recorder.stop_recording(now)  # Ignore return value
 
@@ -818,12 +838,15 @@ class BufferMonitor:
         self.arrival_detection_count = 0
         self.arrival_frame_count = 0
 
-    def _confirm_startup_presence(self) -> None:
+    def _confirm_startup_presence(self, now: datetime) -> None:
         """Confirm startup presence after passing detection threshold.
 
         Similar to _confirm_arrival but:
         - Transitions from PENDING_STARTUP to ROOSTING
         - Only sends notification if notify_on_startup is enabled
+
+        Args:
+            now: The driving frame timestamp (read time, ho-11).
         """
         ratio = self.startup_detection_count / self.startup_frame_count
         logger.event(
@@ -838,7 +861,6 @@ class BufferMonitor:
         self.visit_recorder.rename_to_final()
 
         # Transition from PENDING_STARTUP to ROOSTING
-        now = get_now_tz(self.full_config)
         self.state_machine.confirm_startup_presence(now)
 
         # Send notification only if notify_on_startup is enabled
@@ -856,8 +878,13 @@ class BufferMonitor:
         self.startup_detection_count = 0
         self.startup_frame_count = 0
 
-    def _cancel_startup_presence(self, ratio: float) -> None:
-        """Cancel startup presence - insufficient detections during confirmation window."""
+    def _cancel_startup_presence(self, ratio: float, now: datetime) -> None:
+        """Cancel startup presence - insufficient detections during confirmation window.
+
+        Args:
+            ratio: Detection ratio that failed the confirmation threshold
+            now: The driving frame timestamp (read time, ho-11).
+        """
         logger.warning(
             f"⚠️  STARTUP PRESENCE CANCELLED - detection ratio: {ratio:.1%} "
             f"({self.startup_detection_count}/{self.startup_frame_count} frames, "
@@ -869,7 +896,6 @@ class BufferMonitor:
         visit_tmp = self.visit_recorder.get_temp_path()
 
         # Stop recordings WITHOUT renaming (keeps .tmp extension)
-        now = get_now_tz(self.full_config)
         self.arrival_clip_recorder.stop_recording(now)
         self.visit_recorder.stop_recording(now)
 
@@ -888,11 +914,14 @@ class BufferMonitor:
         # Reset pending state
         self._reset_pending_states()
 
-    def _confirm_recovery(self) -> None:
+    def _confirm_recovery(self, now: datetime) -> None:
         """Confirm falcon still present after stream recovery.
 
         Transitions from PENDING_RECOVERY back to previous state (VISITING/ROOSTING).
         No notification - falcon never actually left.
+
+        Args:
+            now: The driving frame timestamp (read time, ho-11).
         """
         ratio = self.recovery_detection_count / max(self.recovery_frame_count, 1)
         logger.event(
@@ -903,7 +932,6 @@ class BufferMonitor:
         # Confirm recovery in state machine (restores previous state).
         # Pass the actual latest detection time so visit duration isn't
         # inflated by the recovery window length (see 021-J).
-        now = get_now_tz(self.full_config)
         self.state_machine.confirm_recovery_presence(
             now, latest_detection_time=self.recovery_latest_detection
         )
@@ -915,10 +943,14 @@ class BufferMonitor:
         self.recovery_frame_count = 0
         self.recovery_latest_detection = None
 
-    def _cancel_recovery(self, ratio: float) -> None:
+    def _cancel_recovery(self, ratio: float, now: datetime) -> None:
         """Cancel recovery - falcon left during the stream outage.
 
         Generates DEPARTED event with proper clip timing.
+
+        Args:
+            ratio: Detection ratio that failed the confirmation threshold
+            now: The driving frame timestamp (read time, ho-11).
         """
         logger.warning(
             f"⚠️  RECOVERY CANCELLED - falcon left during outage, ratio: {ratio:.1%} "
@@ -927,7 +959,6 @@ class BufferMonitor:
         )
 
         # Get departure events from state machine (uses last_detection from before outage)
-        now = get_now_tz(self.full_config)
         events = self.state_machine.cancel_recovery(now)
 
         # Handle deparure event (create clips, notify, etc.)
@@ -964,6 +995,96 @@ class BufferMonitor:
         self.recovery_frame_count = 0
         self.recovery_latest_detection = None
 
+    def _handle_no_frame_sentinel(self) -> None:
+        """Consume a ``None`` sentinel from the capture (ho-11 / 023-B).
+
+        Called from run() when frames() yields None — no frame arrived
+        within stream_read_timeout_s, including when the underlying read is
+        *blocked*, not just returning failure. This finally engages the
+        long-dormant visit_recorder.write_frame(None) freeze-frame path and
+        its stream_outage_exceeded accounting.
+
+        Uses the wall clock: there is no frame to take a timestamp from —
+        one of the legitimately non-frame contexts.
+        """
+        now = get_now_tz(self.full_config)
+
+        if self._outage_start is None:
+            self._outage_start = now
+            logger.warning(
+                f"⚠️  No frames for {self.stream_read_timeout_s:.0f}s - stream outage in progress"
+            )
+        self._outage_sentinel_count += 1
+
+        if self.visit_recorder.is_recording:
+            # Freeze-frame fill and outage accounting (existing contract —
+            # consumed here, not modified).
+            self.visit_recorder.write_frame(None)
+
+            if self.visit_recorder.stream_outage_exceeded:
+                logger.warning(
+                    "⚠️  Stream outage exceeded during recording - "
+                    "stopping recording and resetting state"
+                )
+                # Stop recording WITHOUT renaming (keeps .tmp extension)
+                self.visit_recorder.stop_recording(now)
+                self.arrival_clip_recorder.stop_recording(now)
+
+                # Reset state machine and pending confirmations
+                self.state_machine.reset_to_absent()
+                self._reset_pending_states()
+
+    def _handle_outage_recovery(self, now: datetime) -> None:
+        """Run outage accounting on the first real frame after a sentinel stretch.
+
+        Args:
+            now: The first post-outage frame's read-time stamp.
+
+        Outage duration is the gap between the last real frame's read time
+        and this frame's read time (falling back to the first-sentinel wall
+        time plus the read timeout when no frame was ever seen). Recovery
+        confirmation entry is unchanged from before ho-11: bird present,
+        outage within stream_recovery_threshold, and a recording active.
+        """
+        if self._last_frame_timestamp is not None:
+            outage_duration = (now - self._last_frame_timestamp).total_seconds()
+        else:
+            # Outage from startup: no frame ever seen. The stretch began
+            # ~read_timeout_s before the first sentinel.
+            assert self._outage_start is not None
+            outage_duration = (
+                now - self._outage_start
+            ).total_seconds() + self.stream_read_timeout_s
+
+        sentinel_count = self._outage_sentinel_count
+        self._outage_start = None
+        self._outage_sentinel_count = 0
+
+        self.state_machine.add_outage(outage_duration)
+        logger.info(
+            f"⚠️  Stream outage detected: {outage_duration:.1f}s ({sentinel_count} sentinel(s))"
+        )
+
+        # Check if bird was present before outage and outage is recoverable
+        if (
+            self.state_machine.is_falcon_present()
+            and outage_duration <= self.stream_recovery_threshold
+            and self.visit_recorder.is_recording
+        ):
+            # Short outage - start recovery confirmation
+            self.state_machine.set_pending_recovery(now)
+
+            self.recovery_pending = True
+            self.recovery_pending_start = now
+            self.recovery_detection_count = 0
+            self.recovery_frame_count = 0
+            self.recovery_latest_detection = None
+
+            logger.info(
+                f"🔄 Starting recovery confirmation "
+                f"({self.stream_recovery_confirmation}s window)"
+            )
+
     def run(self) -> None:
         """Main monitoring loop."""
         logger.info("=" * 60)
@@ -995,8 +1116,6 @@ class BufferMonitor:
         last_heartbeat = time.time()
         heartbeat_interval = 300  # Log heartbeat every 5 minutes
         frames_processed = 0
-        last_frame_time = time.time()
-        frame_timeout = 60  # Warn if no frames for 60 seconds
 
         try:
             for frame in self.capture.frames(skip=0):
@@ -1005,44 +1124,31 @@ class BufferMonitor:
                     logger.info("🛑 Graceful shutdown requested...")
                     break
 
-                # No-frame sentinel from the reader thread (ho-11). Full
-                # outage consumption (freeze-frame fill, outage accounting)
-                # lands in 023-B — until then the sentinel is skipped.
+                # No-frame sentinel from the reader thread (ho-11 / 023-B).
+                # The ONLY outage signal — no second watchdog in this loop.
+                # Sentinels never reach frame processing.
                 if frame is None:
+                    self._handle_no_frame_sentinel()
                     continue
 
                 frames_processed += 1
                 current_time = time.time()
 
-                # Detect if we just recovered from an outage (skip during init)
-                time_since_last_frame = current_time - last_frame_time
-                if initialization_complete and time_since_last_frame > 10:
-                    outage_duration = time_since_last_frame
-                    self.state_machine.add_outage(outage_duration)
-                    logger.info(f"⚠️  Stream outage detected: {outage_duration:.1f}s")
+                # First real frame after an outage stretch: outage accounting
+                # and (for short outages while recording) recovery
+                # confirmation entry — same flow as before ho-11, now keyed
+                # off sentinel data instead of a wall-clock gap heuristic
+                # that was blind to blocked reads.
+                if self._outage_start is not None:
+                    if initialization_complete:
+                        self._handle_outage_recovery(frame.timestamp)
+                    else:
+                        # Outage during startup init — no state to recover
+                        # yet (parity with the pre-ho-11 init skip).
+                        self._outage_start = None
+                        self._outage_sentinel_count = 0
 
-                    # Check if bird was present before outage and outage is recoverable
-                    if (
-                        self.state_machine.is_falcon_present()
-                        and outage_duration <= self.stream_recovery_threshold
-                        and self.visit_recorder.is_recording
-                    ):
-                        # Short outage - start recovery confirmation
-                        now = get_now_tz(self.full_config)
-                        self.state_machine.set_pending_recovery(now)
-
-                        self.recovery_pending = True
-                        self.recovery_pending_start = now
-                        self.recovery_detection_count = 0
-                        self.recovery_frame_count = 0
-                        self.recovery_latest_detection = None
-
-                        logger.info(
-                            f"🔄 Starting recovery confirmation "
-                            f"({self.stream_recovery_confirmation}s window)"
-                        )
-
-                last_frame_time = current_time
+                self._last_frame_timestamp = frame.timestamp
                 elapsed = current_time - start_time
 
                 # Initialization phase - process every frame
@@ -1051,11 +1157,10 @@ class BufferMonitor:
                         initialization_complete = True
                         falcon_detected = len(initial_detections) > 0
 
-                        now = get_now_tz(self.full_config)
+                        # Frame read time drives the init transition too —
+                        # single time authority (ho-11).
+                        now = frame.timestamp
                         initial_state = self.state_machine.initialize_state(falcon_detected, now)
-
-                        # Reset frame time to prevent false outage detection
-                        last_frame_time = current_time
 
                         state_name = initial_state.value
                         if falcon_detected:
@@ -1117,7 +1222,7 @@ class BufferMonitor:
                         logger.info(f"🎯 Normal operation (every {self.process_interval} frames)")
                     else:
                         # Still initializing - detect but don't process events
-                        now = get_now_tz(self.full_config)
+                        now = frame.timestamp
 
                         # Add to buffer
                         self.frame_buffer.add_frame(frame.data, now, frame.frame_number)
@@ -1145,7 +1250,8 @@ class BufferMonitor:
 
                     if self._frame_counter % self.process_interval != 0:
                         # Still add to buffer even when skipping detection
-                        now = get_now_tz(self.full_config)
+                        # (read-time stamp — the single time authority, ho-11)
+                        now = frame.timestamp
                         self.frame_buffer.add_frame(frame.data, now, frame.frame_number)
 
                         # Still write to visit recording
@@ -1172,8 +1278,8 @@ class BufferMonitor:
 
                         continue
 
-                    # Pass outage compensation to process_frame
-                    self.process_frame(frame.data, frame.frame_number)
+                    # Process with the frame's read-time stamp (ho-11)
+                    self.process_frame(frame.data, frame.frame_number, frame.timestamp)
 
                 # Heartbeat logging
                 now_time = time.time()
@@ -1186,14 +1292,8 @@ class BufferMonitor:
                     )
                     last_heartbeat = now_time
 
-                # Watchdog: warn if no frames received recently
-                time_since_frame = now_time - last_frame_time
-                if time_since_frame > frame_timeout:
-                    logger.warning(
-                        f"⚠️  No frames received for {int(time_since_frame)}s - "
-                        f"stream may be stalled"
-                    )
-                    last_frame_time = now_time  # Reset to avoid spam
+                # (No wall-clock frame watchdog here: the no-frame sentinel
+                # from capture is the only outage signal — ho-11.)
 
                 time.sleep(0.01)
 

--- a/tests/test_arrival_confirmation.py
+++ b/tests/test_arrival_confirmation.py
@@ -212,7 +212,7 @@ class TestArrivalConfirmationIntegration:
         monitor.arrival_frame_count = 10
 
         # Trigger cancellation
-        monitor._cancel_arrival(0.2)
+        monitor._cancel_arrival(0.2, now)
 
         # Should reset state machine
         monitor.state_machine.reset_to_absent.assert_called_once()

--- a/tests/test_detection_summary.py
+++ b/tests/test_detection_summary.py
@@ -106,18 +106,15 @@ class TestSummaryCadence:
         now = datetime(2026, 7, 1, 10, 0, 0)
         frame = make_frame()
 
-        with (
-            patch("kanyo.detection.buffer_monitor.get_now_tz", return_value=now),
-            caplog.at_level(EVENT, logger=MONITOR_LOGGER),
-        ):
-            monitor.process_frame(frame, frame_number=0)
+        with caplog.at_level(EVENT, logger=MONITOR_LOGGER):
+            monitor.process_frame(frame, frame_number=0, timestamp=now)
             assert summary_lines(caplog) == []
 
             # Force the window to have elapsed before the second poll
             monitor._summary_window_start = real_time.time() - 301
-            monitor.process_frame(frame, frame_number=1)
+            monitor.process_frame(frame, frame_number=1, timestamp=now)
 
-            monitor.process_frame(frame, frame_number=2)
+            monitor.process_frame(frame, frame_number=2, timestamp=now)
 
         lines = summary_lines(caplog)
         assert len(lines) == 1
@@ -136,12 +133,9 @@ class TestSummaryCadence:
         now = datetime(2026, 7, 1, 10, 0, 0)
         frame = make_frame()
 
-        with (
-            patch("kanyo.detection.buffer_monitor.get_now_tz", return_value=now),
-            caplog.at_level(EVENT, logger=MONITOR_LOGGER),
-        ):
+        with caplog.at_level(EVENT, logger=MONITOR_LOGGER):
             for n in range(5):
-                monitor.process_frame(frame, frame_number=n)
+                monitor.process_frame(frame, frame_number=n, timestamp=now)
 
         assert summary_lines(caplog) == []
         assert monitor._summary_poll_count == 0

--- a/tests/test_frame_timestamp_authority.py
+++ b/tests/test_frame_timestamp_authority.py
@@ -1,0 +1,164 @@
+"""Tests for frame.timestamp as the single time authority (ho-11 / 023-B).
+
+Every frame-derived timestamp — buffer adds, detector polls, state machine
+updates, confirmation windows, last_detection_time — comes from the frame's
+read-time stamp, never from get_now_tz() at processing time. Frames that
+queued during a stall carry the times they were actually read: burst-stamping
+is structurally impossible.
+"""
+
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from kanyo.detection.buffer_monitor import BufferMonitor
+
+T0 = datetime(2026, 7, 16, 12, 0, 0)
+
+
+def make_monitor(**kwargs):
+    """Return a BufferMonitor with all external dependencies mocked out."""
+    with (
+        patch("kanyo.detection.buffer_monitor.StreamCapture"),
+        patch("kanyo.detection.buffer_monitor.FalconDetector"),
+        patch("kanyo.detection.buffer_monitor.FrameBuffer"),
+        patch("kanyo.detection.buffer_monitor.VisitRecorder"),
+        patch("kanyo.detection.buffer_monitor.BufferClipManager"),
+        patch("kanyo.detection.buffer_monitor.EventStore"),
+        patch("kanyo.detection.buffer_monitor.FalconEventHandler"),
+        patch("kanyo.detection.buffer_monitor.FalconStateMachine"),
+        patch("kanyo.detection.buffer_monitor.ArrivalClipRecorder"),
+    ):
+        monitor = BufferMonitor(stream_url="test", **kwargs)
+    _quiet_frame_mocks(monitor)
+    return monitor
+
+
+def _quiet_frame_mocks(monitor) -> None:
+    """Configure recorder/buffer mocks so process_frame runs the poll path."""
+    monitor.visit_recorder.is_recording = False
+    monitor.arrival_clip_recorder.is_recording.return_value = False
+    monitor.frame_buffer.add_frame.return_value = None
+    monitor.state_machine.update.return_value = []
+    monitor.detector.detect_birds.return_value = []
+
+
+def detection(conf: float = 0.8):
+    return SimpleNamespace(confidence=conf)
+
+
+def make_frame():
+    frame = MagicMock()
+    frame.shape = (720, 1280, 3)
+    return frame
+
+
+class TestProcessFrameTimeAuthority:
+    """process_frame derives every timestamp from the passed frame stamp."""
+
+    def test_buffer_add_uses_frame_timestamp(self):
+        monitor = make_monitor()
+        frame = make_frame()
+
+        monitor.process_frame(frame, frame_number=7, timestamp=T0)
+
+        monitor.frame_buffer.add_frame.assert_called_once_with(frame, T0, 7)
+
+    def test_detector_poll_uses_frame_timestamp(self):
+        monitor = make_monitor()
+        frame = make_frame()
+
+        monitor.process_frame(frame, frame_number=1, timestamp=T0)
+
+        monitor.detector.detect_birds.assert_called_once_with(frame, timestamp=T0)
+
+    def test_state_machine_update_uses_frame_timestamp(self):
+        monitor = make_monitor()
+
+        monitor.process_frame(make_frame(), frame_number=1, timestamp=T0)
+
+        monitor.state_machine.update.assert_called_once_with(False, T0)
+
+    def test_last_detection_time_is_frame_timestamp(self):
+        monitor = make_monitor()
+        monitor.detector.detect_birds.return_value = [detection(0.9)]
+
+        monitor.process_frame(make_frame(), frame_number=1, timestamp=T0)
+
+        assert monitor.last_detection_time == T0
+
+    def test_no_processing_time_stamping_in_per_frame_path(self):
+        """The per-frame data path never re-stamps with get_now_tz()."""
+        monitor = make_monitor()
+        monitor.detector.detect_birds.return_value = [detection(0.9)]
+
+        with patch("kanyo.detection.buffer_monitor.get_now_tz") as mock_now:
+            monitor.process_frame(make_frame(), frame_number=1, timestamp=T0)
+
+        mock_now.assert_not_called()
+
+    def test_stall_then_drain_keeps_read_time_spacing(self):
+        """Frames stamped 1s apart at read time, consumed in a tight burst:
+        buffer and state machine see monotonic ~1s spacing, not a run of
+        near-identical processing-time stamps."""
+        monitor = make_monitor()
+        stamps = [T0 + timedelta(seconds=i) for i in range(5)]
+
+        for n, stamp in enumerate(stamps):
+            monitor.process_frame(make_frame(), frame_number=n, timestamp=stamp)
+
+        buffer_stamps = [c.args[1] for c in monitor.frame_buffer.add_frame.call_args_list]
+        update_stamps = [c.args[1] for c in monitor.state_machine.update.call_args_list]
+        assert buffer_stamps == stamps
+        assert update_stamps == stamps
+
+
+class TestConfirmationWindowsTimeAuthority:
+    """Confirmation windows measure and stamp with frame read times."""
+
+    def test_recovery_confirmation_uses_frame_timestamps(self):
+        """A detected frame past the recovery window confirms with the
+        frame's stamp as both confirmation time and latest detection (021-J
+        semantics preserved, driven by read time)."""
+        monitor = make_monitor(stream_recovery_confirmation=10)
+        monitor.detector.detect_birds.return_value = [detection(0.9)]
+        monitor.recovery_pending = True
+        monitor.recovery_pending_start = T0
+
+        ts = T0 + timedelta(seconds=11)
+        monitor.process_frame(make_frame(), frame_number=1, timestamp=ts)
+
+        monitor.state_machine.confirm_recovery_presence.assert_called_once_with(
+            ts, latest_detection_time=ts
+        )
+        assert monitor.recovery_pending is False
+
+    def test_startup_confirmation_uses_frame_timestamps(self):
+        """Startup presence confirms at the driving frame's read time."""
+        monitor = make_monitor()
+        monitor.detector.detect_birds.return_value = [detection(0.9)]
+        monitor.startup_pending = True
+        monitor.startup_pending_start = T0
+        monitor.startup_detection_count = 5
+        monitor.startup_frame_count = 5
+
+        ts = T0 + timedelta(seconds=monitor.arrival_confirmation_seconds + 1)
+        monitor.process_frame(make_frame(), frame_number=1, timestamp=ts)
+
+        monitor.state_machine.confirm_startup_presence.assert_called_once_with(ts)
+        assert monitor.startup_pending is False
+
+    def test_cancel_recovery_uses_frame_timestamp(self):
+        """A failed recovery cancels through the state machine with the
+        driving frame's read time."""
+        monitor = make_monitor(stream_recovery_confirmation=10)
+        monitor.detector.detect_birds.return_value = []
+        monitor.state_machine.cancel_recovery.return_value = []
+        monitor.recovery_pending = True
+        monitor.recovery_pending_start = T0
+
+        ts = T0 + timedelta(seconds=11)
+        monitor.process_frame(make_frame(), frame_number=1, timestamp=ts)
+
+        monitor.state_machine.cancel_recovery.assert_called_once_with(ts)
+        assert monitor.recovery_pending is False

--- a/tests/test_outage_sentinel.py
+++ b/tests/test_outage_sentinel.py
@@ -1,0 +1,245 @@
+"""Tests for no-frame sentinel consumption in the monitor (ho-11 / 023-B).
+
+The sentinel from capture is the only outage signal. While a visit is
+recording it finally engages visit_recorder.write_frame(None) — freeze-frame
+fill and stream_outage_exceeded accounting — and outage stretches key
+state_machine.add_outage and recovery-confirmation entry off sentinel data
+instead of a wall-clock gap heuristic that was blind to blocked reads.
+"""
+
+import itertools
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+
+from kanyo.detection.buffer_monitor import BufferMonitor
+
+T0 = datetime(2026, 7, 16, 12, 0, 0)
+
+
+def make_monitor(**kwargs):
+    """Return a BufferMonitor with all external dependencies mocked out."""
+    with (
+        patch("kanyo.detection.buffer_monitor.StreamCapture"),
+        patch("kanyo.detection.buffer_monitor.FalconDetector"),
+        patch("kanyo.detection.buffer_monitor.FrameBuffer"),
+        patch("kanyo.detection.buffer_monitor.VisitRecorder"),
+        patch("kanyo.detection.buffer_monitor.BufferClipManager"),
+        patch("kanyo.detection.buffer_monitor.EventStore"),
+        patch("kanyo.detection.buffer_monitor.FalconEventHandler"),
+        patch("kanyo.detection.buffer_monitor.FalconStateMachine"),
+        patch("kanyo.detection.buffer_monitor.ArrivalClipRecorder"),
+    ):
+        monitor = BufferMonitor(stream_url="test", **kwargs)
+    return monitor
+
+
+def make_frame(frame_number: int, timestamp: datetime):
+    """Minimal stand-in for a capture Frame with a read-time stamp."""
+    return SimpleNamespace(
+        data=np.zeros((4, 4, 3), dtype=np.uint8),
+        frame_number=frame_number,
+        timestamp=timestamp,
+    )
+
+
+class TestSentinelHandling:
+    """_handle_no_frame_sentinel: the per-sentinel consumption path."""
+
+    def test_sentinel_writes_freeze_frame_while_recording(self):
+        """An active recording receives write_frame(None) per sentinel."""
+        monitor = make_monitor()
+        monitor.visit_recorder.is_recording = True
+        monitor.visit_recorder.stream_outage_exceeded = False
+
+        monitor._handle_no_frame_sentinel()
+
+        monitor.visit_recorder.write_frame.assert_called_once_with(None)
+        assert monitor._outage_start is not None
+        assert monitor._outage_sentinel_count == 1
+
+    def test_sentinel_without_recording_leaves_recorder_untouched(self):
+        """No recording: sentinels must not crash and must not touch the recorder."""
+        monitor = make_monitor()
+        monitor.visit_recorder.is_recording = False
+
+        monitor._handle_no_frame_sentinel()
+        monitor._handle_no_frame_sentinel()
+
+        monitor.visit_recorder.write_frame.assert_not_called()
+        monitor.visit_recorder.stop_recording.assert_not_called()
+        assert monitor._outage_sentinel_count == 2
+
+    def test_outage_exceeded_stops_recording_and_resets_state(self):
+        """stream_outage_exceeded runs the existing stop/reset path."""
+        monitor = make_monitor()
+        monitor.visit_recorder.is_recording = True
+        monitor.visit_recorder.stream_outage_exceeded = True
+        monitor.arrival_pending = True
+        monitor._visit_peak_confidence = 0.9
+
+        monitor._handle_no_frame_sentinel()
+
+        monitor.visit_recorder.write_frame.assert_called_once_with(None)
+        monitor.visit_recorder.stop_recording.assert_called_once()
+        monitor.arrival_clip_recorder.stop_recording.assert_called_once()
+        monitor.state_machine.reset_to_absent.assert_called_once()
+        # Pending confirmations and the visit peak are discarded
+        assert monitor.arrival_pending is False
+        assert monitor._visit_peak_confidence == 0.0
+
+    def test_outage_start_fixed_across_sentinel_stretch(self):
+        """The stretch keeps its first-sentinel time; only the count grows."""
+        monitor = make_monitor()
+        monitor.visit_recorder.is_recording = False
+
+        monitor._handle_no_frame_sentinel()
+        first_start = monitor._outage_start
+        monitor._handle_no_frame_sentinel()
+        monitor._handle_no_frame_sentinel()
+
+        assert monitor._outage_start is first_start
+        assert monitor._outage_sentinel_count == 3
+
+
+class TestOutageRecovery:
+    """_handle_outage_recovery: first real frame after a sentinel stretch."""
+
+    def _in_outage(self, monitor, last_frame_at: datetime, sentinels: int = 2):
+        monitor._last_frame_timestamp = last_frame_at
+        monitor._outage_start = last_frame_at + timedelta(seconds=10)
+        monitor._outage_sentinel_count = sentinels
+
+    def test_short_outage_with_bird_enters_recovery_confirmation(self):
+        """Bird present + outage within threshold + recording -> PENDING_RECOVERY."""
+        monitor = make_monitor(stream_recovery_threshold=30)
+        self._in_outage(monitor, T0)
+        monitor.state_machine.is_falcon_present.return_value = True
+        monitor.visit_recorder.is_recording = True
+
+        now = T0 + timedelta(seconds=20)
+        monitor._handle_outage_recovery(now)
+
+        monitor.state_machine.add_outage.assert_called_once_with(20.0)
+        monitor.state_machine.set_pending_recovery.assert_called_once_with(now)
+        assert monitor.recovery_pending is True
+        assert monitor.recovery_pending_start == now
+        assert monitor.recovery_detection_count == 0
+        assert monitor.recovery_latest_detection is None
+        # Outage stretch is consumed
+        assert monitor._outage_start is None
+        assert monitor._outage_sentinel_count == 0
+
+    def test_long_outage_accounts_but_does_not_enter_recovery(self):
+        """Outage past the threshold: add_outage only, no recovery window."""
+        monitor = make_monitor(stream_recovery_threshold=30)
+        self._in_outage(monitor, T0, sentinels=12)
+        monitor.state_machine.is_falcon_present.return_value = True
+        monitor.visit_recorder.is_recording = True
+
+        monitor._handle_outage_recovery(T0 + timedelta(seconds=120))
+
+        monitor.state_machine.add_outage.assert_called_once_with(120.0)
+        monitor.state_machine.set_pending_recovery.assert_not_called()
+        assert monitor.recovery_pending is False
+
+    def test_no_recording_means_no_recovery_window(self):
+        """Recovery confirmation requires an active recording, as before."""
+        monitor = make_monitor(stream_recovery_threshold=30)
+        self._in_outage(monitor, T0)
+        monitor.state_machine.is_falcon_present.return_value = True
+        monitor.visit_recorder.is_recording = False
+
+        monitor._handle_outage_recovery(T0 + timedelta(seconds=15))
+
+        monitor.state_machine.add_outage.assert_called_once_with(15.0)
+        monitor.state_machine.set_pending_recovery.assert_not_called()
+        assert monitor.recovery_pending is False
+
+    def test_startup_outage_duration_falls_back_to_sentinel_time(self):
+        """With no frame ever seen, duration estimates from the first
+        sentinel plus the read timeout."""
+        monitor = make_monitor(stream_read_timeout_s=10.0)
+        monitor._last_frame_timestamp = None
+        monitor._outage_start = T0
+        monitor._outage_sentinel_count = 1
+        monitor.state_machine.is_falcon_present.return_value = False
+
+        monitor._handle_outage_recovery(T0 + timedelta(seconds=15))
+
+        monitor.state_machine.add_outage.assert_called_once_with(25.0)
+
+
+class TestRunLoopSentinelWiring:
+    """run() routes sentinels and post-outage frames to the handlers."""
+
+    def _runnable_monitor(self):
+        monitor = make_monitor(stream_recovery_threshold=30)
+        # Shutdown path needs an unpackable stop_recording result
+        monitor.visit_recorder.stop_recording.return_value = (None, None)
+        monitor.arrival_clip_recorder.is_recording.return_value = False
+        monitor.state_machine.update.return_value = []
+        return monitor
+
+    def test_frames_sentinels_frames_drives_outage_and_recovery(self):
+        """frames -> sentinels -> frame: freeze-frame fill per sentinel while
+        recording, then outage accounting + recovery entry on the first real
+        frame (021-F's integration case)."""
+        monitor = self._runnable_monitor()
+        monitor.visit_recorder.is_recording = True
+        monitor.visit_recorder.stream_outage_exceeded = False
+        monitor.state_machine.is_falcon_present.return_value = True
+
+        f1 = make_frame(1, T0)
+        f2 = make_frame(2, T0 + timedelta(seconds=20))
+        monitor.capture.frames.return_value = iter([f1, None, None, f2])
+
+        with (
+            patch("kanyo.detection.buffer_monitor.signal"),
+            patch("kanyo.detection.buffer_monitor.time") as mock_time,
+        ):
+            # First frame arrives past the 30s init window so initialization
+            # completes immediately (empty init detections -> ABSENT-style
+            # init; the mocked state machine absorbs it).
+            mock_time.time.side_effect = itertools.count(0, 31)
+            mock_time.sleep = MagicMock()
+            monitor.run()
+
+        # Each sentinel fed the freeze-frame path of the active recording
+        none_writes = [
+            c for c in monitor.visit_recorder.write_frame.call_args_list if c.args[0] is None
+        ]
+        assert len(none_writes) == 2
+
+        # First real frame after the stretch ran outage accounting with the
+        # frame-timestamp gap (20s) and entered recovery confirmation
+        monitor.state_machine.add_outage.assert_called_once_with(20.0)
+        monitor.state_machine.set_pending_recovery.assert_called_once_with(f2.timestamp)
+        assert monitor.recovery_pending is True
+        assert monitor.recovery_pending_start == f2.timestamp
+
+    def test_sentinels_without_recording_do_not_crash_run(self):
+        """Sentinel-only outage with no active recording: run() survives and
+        the recorder is never fed."""
+        monitor = self._runnable_monitor()
+        monitor.visit_recorder.is_recording = False
+        monitor.state_machine.is_falcon_present.return_value = False
+
+        f1 = make_frame(1, T0)
+        f2 = make_frame(2, T0 + timedelta(seconds=45))
+        monitor.capture.frames.return_value = iter([f1, None, None, None, f2])
+
+        with (
+            patch("kanyo.detection.buffer_monitor.signal"),
+            patch("kanyo.detection.buffer_monitor.time") as mock_time,
+        ):
+            mock_time.time.side_effect = itertools.count(0, 31)
+            mock_time.sleep = MagicMock()
+            monitor.run()
+
+        monitor.visit_recorder.write_frame.assert_not_called()
+        monitor.state_machine.add_outage.assert_called_once_with(45.0)
+        monitor.state_machine.set_pending_recovery.assert_not_called()
+        assert monitor.recovery_pending is False

--- a/tests/test_roosting_departure_candidate.py
+++ b/tests/test_roosting_departure_candidate.py
@@ -68,8 +68,7 @@ def run_poll(monitor, detections, now):
     monitor.detector.detect_birds.return_value = detections
     # Ensure the roosting interval gate lets the poll through
     monitor.last_roosting_check = now - timedelta(seconds=31)
-    with patch("kanyo.detection.buffer_monitor.get_now_tz", return_value=now):
-        monitor.process_frame(make_frame(), frame_number=1)
+    monitor.process_frame(make_frame(), frame_number=1, timestamp=now)
 
 
 class TestCandidateSnapshot:

--- a/tests/test_roosting_mode.py
+++ b/tests/test_roosting_mode.py
@@ -72,7 +72,10 @@ class TestRoostingEventHandler:
         now = datetime(2026, 4, 21, 10, 0, 0)
 
         monitor.visit_recorder.is_recording = True
-        monitor.visit_recorder.stop_recording.return_value = ("/fake/visit.mp4", {"visit_start": now})
+        monitor.visit_recorder.stop_recording.return_value = (
+            "/fake/visit.mp4",
+            {"visit_start": now},
+        )
 
         monitor._handle_event(FalconEvent.ROOSTING, now, {})
 
@@ -84,7 +87,10 @@ class TestRoostingEventHandler:
         now = datetime(2026, 4, 21, 10, 0, 0)
 
         monitor.visit_recorder.is_recording = True
-        monitor.visit_recorder.stop_recording.return_value = ("/fake/visit.mp4", {"visit_start": now})
+        monitor.visit_recorder.stop_recording.return_value = (
+            "/fake/visit.mp4",
+            {"visit_start": now},
+        )
 
         monitor._handle_event(FalconEvent.ROOSTING, now, {})
 
@@ -133,6 +139,7 @@ class TestRoostingYOLOGating:
 
     def _make_frame(self):
         import numpy as np
+
         return np.zeros((720, 1280, 3), dtype="uint8")
 
     def test_yolo_skipped_within_interval(self):
@@ -144,9 +151,8 @@ class TestRoostingYOLOGating:
         monitor.roosting_mode_active = True
         monitor.last_roosting_check = now  # just checked
 
-        # Call process_frame 5 seconds later
-        with patch("kanyo.detection.buffer_monitor.get_now_tz", return_value=now + timedelta(seconds=5)):
-            monitor.process_frame(frame, frame_number=1)
+        # Call process_frame 5 seconds later (frame read-time stamp, ho-11)
+        monitor.process_frame(frame, frame_number=1, timestamp=now + timedelta(seconds=5))
 
         monitor.detector.detect_birds.assert_not_called()
 
@@ -165,8 +171,7 @@ class TestRoostingYOLOGating:
         monitor.arrival_clip_recorder.is_recording.return_value = False
         monitor.frame_buffer.add_frame.return_value = None
 
-        with patch("kanyo.detection.buffer_monitor.get_now_tz", return_value=now):
-            monitor.process_frame(frame, frame_number=1)
+        monitor.process_frame(frame, frame_number=1, timestamp=now)
 
         monitor.detector.detect_birds.assert_called_once()
 
@@ -184,8 +189,7 @@ class TestRoostingYOLOGating:
         monitor.arrival_clip_recorder.is_recording.return_value = False
         monitor.frame_buffer.add_frame.return_value = None
 
-        with patch("kanyo.detection.buffer_monitor.get_now_tz", return_value=now):
-            monitor.process_frame(frame, frame_number=1)
+        monitor.process_frame(frame, frame_number=1, timestamp=now)
 
         monitor.detector.detect_birds.assert_called_once()
 
@@ -213,7 +217,8 @@ class TestRoostingDeparture:
             monitor._handle_event(FalconEvent.DEPARTED, now, metadata)
 
         monitor.clip_manager.create_clip_from_buffer.assert_called_once_with(
-            now, "departure",
+            now,
+            "departure",
             before_seconds=30,
             after_seconds=15,
         )

--- a/tests/test_visit_record_fields.py
+++ b/tests/test_visit_record_fields.py
@@ -69,9 +69,8 @@ class TestPeakConfidenceTracking:
         now = datetime(2026, 7, 1, 10, 0, 0)
         frame = MagicMock()
         frame.shape = (720, 1280, 3)
-        with patch("kanyo.detection.buffer_monitor.get_now_tz", return_value=now):
-            for n in range(4):
-                monitor.process_frame(frame, frame_number=n)
+        for n in range(4):
+            monitor.process_frame(frame, frame_number=n, timestamp=now)
 
         assert monitor._visit_peak_confidence == 0.8
 
@@ -92,7 +91,7 @@ class TestPeakConfidenceTracking:
         monitor.arrival_clip_recorder.get_temp_path.return_value = None
         monitor.visit_recorder.get_temp_path.return_value = None
 
-        monitor._cancel_arrival(ratio=0.1)
+        monitor._cancel_arrival(ratio=0.1, now=datetime(2026, 7, 1, 10, 0, 5))
 
         assert monitor._visit_peak_confidence == 0.0
 


### PR DESCRIPTION
## Summary

Monitor-side half of ho-11 (depends on #36). The `None` sentinel from capture is now the only outage signal, and every frame-derived timestamp comes from the frame's read-time stamp — burst-stamping after stalls is structurally impossible.

**Sentinel consumption in `run()`**
- While a visit is recording, each sentinel calls `visit_recorder.write_frame(None)` — the long-dormant freeze-frame fill and `stream_outage_exceeded` accounting finally engage; the exceeded flag runs the existing stop/reset path. No recording → sentinels are tracked but the recorder is untouched.
- Outage stretches track first-sentinel time and count; the first real frame after a stretch runs `state_machine.add_outage()` with the gap between frame read times and the unchanged recovery-confirmation entry (present + within `stream_recovery_threshold` + recording → PENDING_RECOVERY).
- The wall-clock gap heuristic and the 60s frame watchdog are removed — both were blind to blocked reads, and the heuristic false-positived on slow processing. The sentinel is the only watchdog (021-F ruling).

**Time authority**
- `process_frame(frame_data, frame_number, timestamp)`; `now = timestamp`.
- Init loop, init-complete transition, and skip path use `frame.timestamp` for buffer adds, recorder writes, detection polls.
- `_cancel_arrival`, `_confirm/_cancel_startup_presence`, `_confirm/_cancel_recovery` take the driving timestamp instead of re-stamping. `get_now_tz()` survives only in non-frame contexts (sentinel wall clock, shutdown finalization, wall-clock scheduling).
- `visit_recorder.write_frame(None)` contract verified and consumed, not modified.

## Deviations from spec

- The spec said outage accounting should key off "first-sentinel time, count"; duration is instead measured from the last real frame's read-time stamp to the first post-outage frame — the same gap the old heuristic measured, now with trustworthy times (first-sentinel time + `stream_read_timeout_s` is the fallback when no frame was ever seen). Sentinel count is logged.
- Note on cadence: `write_frame(None)` counts calls against `_max_none_frames` (≈ `stream_recovery_threshold × fps`); with one sentinel per `stream_read_timeout_s` the exceeded flag effectively defers to the recovery/exit paths in production, matching today's observed behavior (the flag never fired at all before). Semantics unchanged, threshold meaning noted for ho-12+.

## Testing

- New `tests/test_outage_sentinel.py`: freeze-frame per sentinel, no-recording no-op, exceeded stop/reset, short/long/no-recording/startup-fallback recovery, plus `run()` integration driving frames → sentinels → frames with and without an active recording.
- New `tests/test_frame_timestamp_authority.py`: buffer/detector/state-machine stamps, `last_detection_time`, confirmation windows (incl. 021-J `latest_detection_time`), no `get_now_tz` in the per-frame path, stall-then-drain monotonic 1s spacing.
- `black`/`isort` applied, `mypy src/` clean, 362 passed — only the 4 pre-existing failures on main.