### PR TITLE
024-A: Detector raw-detections path (single low-floor inference)

### DIFF
--- a/src/kanyo/detection/detect.py
+++ b/src/kanyo/detection/detect.py
@@ -88,6 +88,7 @@ class FalconDetector:
         target_classes: list[int] | None = None,
         detect_any_animal: bool = True,
         animal_classes: list[int] | None = None,
+        raw_floor_confidence: float | None = None,
     ):
         """
         Initialize detector.
@@ -100,11 +101,18 @@ class FalconDetector:
             detect_any_animal: If True, detect any animal (for falcon cams where
                                the model may misclassify falcons as cats/dogs)
             animal_classes: COCO class IDs to treat as "animal" when detect_any_animal=True
+            raw_floor_confidence: Optional low floor for the raw-detections view
+                (presence layer). When set, the single model call runs at
+                min(raw_floor_confidence, effective threshold) and the existing
+                filtered semantics are reproduced by post-filtering in code.
+                When None, behavior is exactly the historical single-threshold
+                call.
         """
         self.model_path = Path(model_path)
         self.confidence_threshold = confidence_threshold
         self.confidence_threshold_ir = confidence_threshold_ir
         self.detect_any_animal = detect_any_animal
+        self.raw_floor_confidence = raw_floor_confidence
 
         # Use provided animal_classes or fall back to ANIMAL_CLASS_IDS keys
         default_animals = list(ANIMAL_CLASS_IDS.keys())
@@ -126,6 +134,109 @@ class FalconDetector:
             logger.info("Model loaded successfully")
         return self._model
 
+    def _run_inference(
+        self,
+        frame: NDArray[np.uint8],
+        timestamp: datetime,
+    ) -> tuple[list[Detection], list[Detection]]:
+        """
+        Run ONE YOLO inference and return two post-filtered views.
+
+        Returns:
+            (filtered, raw) where:
+            - filtered: target classes only, confidence >= effective threshold
+              (respecting the IR-mode switch) — byte-identical semantics to the
+              historical single-threshold model call.
+            - raw: every box of every class with confidence >=
+              raw_floor_confidence (falls back to the effective threshold when
+              the floor is unset). Presence-layer evidence: at-lens birds that
+              classify as "elephant" or "person" live here.
+
+        The model is invoked exactly once per call. When raw_floor_confidence
+        is set, the call runs at min(raw_floor_confidence, effective threshold)
+        and the filtered view is reconstructed in code.
+        """
+        # Determine effective threshold based on IR mode
+        ir_mode = is_ir_mode(frame)
+        if ir_mode and self.confidence_threshold_ir is not None:
+            effective_threshold = self.confidence_threshold_ir
+        else:
+            effective_threshold = self.confidence_threshold
+
+        if self.raw_floor_confidence is not None:
+            model_conf = min(self.raw_floor_confidence, effective_threshold)
+            raw_floor = self.raw_floor_confidence
+        else:
+            model_conf = effective_threshold
+            raw_floor = effective_threshold
+
+        results = self.model(
+            frame,
+            conf=model_conf,
+            verbose=False,
+        )
+
+        filtered: list[Detection] = []
+        raw: list[Detection] = []
+        total_checked = 0
+        all_detections_debug = []
+
+        for result in results:
+            for box in result.boxes:
+                total_checked += 1
+                class_id = int(box.cls[0])
+                confidence = float(box.conf[0])
+                class_name = result.names[class_id]
+
+                # Debug: log ALL detections
+                all_detections_debug.append(f"{class_name}({class_id}):{confidence:.2f}")
+
+                bbox_list = list(map(int, box.xyxy[0].tolist()))
+                bbox: tuple[int, int, int, int] = (
+                    bbox_list[0],
+                    bbox_list[1],
+                    bbox_list[2],
+                    bbox_list[3],
+                )
+                detection = Detection(
+                    class_id=class_id,
+                    class_name=class_name,
+                    confidence=confidence,
+                    bbox=bbox,
+                    timestamp=timestamp,
+                )
+
+                if confidence >= raw_floor:
+                    raw.append(detection)
+
+                # Filtered view: target classes at the effective threshold —
+                # the pre-raw-floor semantics, preserved for existing callers.
+                if class_id in self.target_classes and confidence >= effective_threshold:
+                    filtered.append(detection)
+
+        # Debug logging
+        if all_detections_debug:
+            logger.debug(
+                f"YOLO found {total_checked} objects: {', '.join(all_detections_debug[:5])}"
+            )
+
+        if filtered:
+            max_confidence = max(d.confidence for d in filtered)
+            mode_str = "IR" if ir_mode else "DAY"
+            logger.debug(
+                f"[{mode_str}] Falcon detected: confidence={max_confidence:.3f} "
+                f"(threshold={effective_threshold:.2f})"
+            )
+        else:
+            mode_str = "IR" if ir_mode else "DAY"
+            logger.debug(
+                f"[{mode_str}] No falcon detected "
+                f"(checked {total_checked} detections, "
+                f"threshold={effective_threshold:.2f})"
+            )
+
+        return filtered, raw
+
     def detect(
         self,
         frame: NDArray[np.uint8],
@@ -142,76 +253,30 @@ class FalconDetector:
             List of Detection objects
         """
         timestamp = timestamp or datetime.now()
+        filtered, _ = self._run_inference(frame, timestamp)
+        return filtered
 
-        # Determine effective threshold based on IR mode
-        ir_mode = is_ir_mode(frame)
-        if ir_mode and self.confidence_threshold_ir is not None:
-            effective_threshold = self.confidence_threshold_ir
-        else:
-            effective_threshold = self.confidence_threshold
+    def detect_with_raw(
+        self,
+        frame: NDArray[np.uint8],
+        timestamp: datetime | None = None,
+    ) -> tuple[list[Detection], list[Detection]]:
+        """
+        Run ONE inference and return (filtered, raw) detections.
 
-        results = self.model(
-            frame,
-            conf=effective_threshold,
-            verbose=False,
-        )
+        filtered is exactly what detect_birds() returns today; raw is every
+        box of every class at or above raw_floor_confidence (or the effective
+        threshold when the floor is unset). See _run_inference for details.
 
-        detections = []
-        total_checked = 0
-        all_detections_debug = []
+        Args:
+            frame: BGR image as numpy array
+            timestamp: When this frame was captured (default: now)
 
-        for result in results:
-            for box in result.boxes:
-                total_checked += 1
-                class_id = int(box.cls[0])
-                confidence = float(box.conf[0])
-                class_name = result.names[class_id]
-
-                # Debug: log ALL detections
-                all_detections_debug.append(f"{class_name}({class_id}):{confidence:.2f}")
-
-                # Only include detections matching target classes
-                if class_id not in self.target_classes:
-                    continue
-                bbox_list = list(map(int, box.xyxy[0].tolist()))
-                bbox: tuple[int, int, int, int] = (
-                    bbox_list[0],
-                    bbox_list[1],
-                    bbox_list[2],
-                    bbox_list[3],
-                )
-                detections.append(
-                    Detection(
-                        class_id=class_id,
-                        class_name=class_name,
-                        confidence=confidence,
-                        bbox=bbox,
-                        timestamp=timestamp,
-                    )
-                )
-
-        # Debug logging
-        if all_detections_debug:
-            logger.debug(
-                f"YOLO found {total_checked} objects: {', '.join(all_detections_debug[:5])}"
-            )
-
-        if detections:
-            max_confidence = max(d.confidence for d in detections)
-            mode_str = "IR" if ir_mode else "DAY"
-            logger.debug(
-                f"[{mode_str}] Falcon detected: confidence={max_confidence:.3f} "
-                f"(threshold={effective_threshold:.2f})"
-            )
-        else:
-            mode_str = "IR" if ir_mode else "DAY"
-            logger.debug(
-                f"[{mode_str}] No falcon detected "
-                f"(checked {total_checked} detections, "
-                f"threshold={effective_threshold:.2f})"
-            )
-
-        return detections
+        Returns:
+            Tuple of (filtered, raw) Detection lists from a single inference.
+        """
+        timestamp = timestamp or datetime.now()
+        return self._run_inference(frame, timestamp)
 
     def detect_birds(
         self,

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -136,6 +136,178 @@ class TestFalconDetector:
         assert len(detection.bbox) == 4
 
 
+def _mock_yolo_results(boxes):
+    """Build a fake ultralytics results list from (class_id, confidence, bbox) tuples."""
+    names = {0: "person", 14: "bird", 15: "cat", 20: "elephant"}
+    result = Mock()
+    result.names = names
+    mock_boxes = []
+    for class_id, confidence, bbox in boxes:
+        box = Mock()
+        box.cls = [class_id]
+        box.conf = [confidence]
+        xyxy_entry = Mock()
+        xyxy_entry.tolist.return_value = list(bbox)
+        box.xyxy = [xyxy_entry]
+        mock_boxes.append(box)
+    result.boxes = mock_boxes
+    return [result]
+
+
+def _color_frame():
+    """A frame that is NOT IR mode (R, G, B clearly distinct)."""
+    frame = np.zeros((480, 640, 3), dtype=np.uint8)
+    frame[:, :, 0] = 100  # Blue
+    frame[:, :, 1] = 150  # Green
+    frame[:, :, 2] = 200  # Red
+    return frame
+
+
+def _ir_frame():
+    """A grayscale frame that IS IR mode (R == G == B)."""
+    return np.ones((480, 640, 3), dtype=np.uint8) * 128
+
+
+class TestDetectWithRaw:
+    """Tests for the raw-detections path (024-A): one inference, two views."""
+
+    TS = datetime(2026, 7, 16, 12, 0, 0)
+
+    def _detector(self, **kwargs):
+        from kanyo.detection.detect import FalconDetector
+
+        return FalconDetector(confidence_threshold=0.5, **kwargs)
+
+    def test_filtered_raw_split(self):
+        """Low-confidence any-class boxes land in raw; filtered keeps today's semantics."""
+        detector = self._detector(raw_floor_confidence=0.15)
+        detector._model = Mock(
+            return_value=_mock_yolo_results(
+                [
+                    (14, 0.6, (100, 100, 150, 150)),  # bird above threshold -> both
+                    (20, 0.2, (200, 200, 300, 300)),  # elephant, low conf -> raw only
+                    (0, 0.89, (10, 10, 50, 50)),  # person, high conf, non-target -> raw only
+                    (14, 0.1, (400, 400, 420, 420)),  # bird below raw floor -> neither
+                ]
+            )
+        )
+
+        filtered, raw = detector.detect_with_raw(_color_frame(), timestamp=self.TS)
+
+        assert [(d.class_id, d.confidence) for d in filtered] == [(14, 0.6)]
+        assert [(d.class_id, d.confidence) for d in raw] == [(14, 0.6), (20, 0.2), (0, 0.89)]
+        # Detection objects carry the full field set
+        elephant = raw[1]
+        assert elephant.class_name == "elephant"
+        assert elephant.bbox == (200, 200, 300, 300)
+        assert elephant.timestamp == self.TS
+
+    def test_single_inference_at_min_conf(self):
+        """Exactly one model call per detect_with_raw, at min(floor, threshold)."""
+        detector = self._detector(raw_floor_confidence=0.15)
+        model = Mock(return_value=_mock_yolo_results([]))
+        detector._model = model
+
+        detector.detect_with_raw(_color_frame(), timestamp=self.TS)
+
+        assert model.call_count == 1
+        assert model.call_args.kwargs["conf"] == 0.15
+
+    def test_none_floor_preserves_existing_behavior(self):
+        """With raw_floor_confidence=None the model call and outputs match today's."""
+        boxes = [
+            (14, 0.6, (100, 100, 150, 150)),  # bird, target class
+            (20, 0.7, (200, 200, 300, 300)),  # elephant, target class (detect_any_animal)
+            (0, 0.89, (10, 10, 50, 50)),  # person, non-target -> excluded
+        ]
+        detector = self._detector()  # raw_floor_confidence defaults to None
+        model = Mock(return_value=_mock_yolo_results(boxes))
+        detector._model = model
+
+        detections = detector.detect(_color_frame(), timestamp=self.TS)
+
+        assert model.call_count == 1
+        assert model.call_args.kwargs["conf"] == 0.5  # unchanged model-call threshold
+        assert [(d.class_id, d.confidence) for d in detections] == [(14, 0.6), (20, 0.7)]
+
+        # detect_birds re-filters to the same set
+        model2 = Mock(return_value=_mock_yolo_results(boxes))
+        detector._model = model2
+        birds = detector.detect_birds(_color_frame(), timestamp=self.TS)
+        assert birds == detections
+
+    def test_none_floor_raw_falls_back_to_effective_threshold(self):
+        """Unset floor: raw contains any class at or above the effective threshold."""
+        detector = self._detector()
+        detector._model = Mock(
+            return_value=_mock_yolo_results(
+                [
+                    (14, 0.6, (100, 100, 150, 150)),
+                    (0, 0.89, (10, 10, 50, 50)),
+                ]
+            )
+        )
+
+        filtered, raw = detector.detect_with_raw(_color_frame(), timestamp=self.TS)
+
+        assert [(d.class_id, d.confidence) for d in filtered] == [(14, 0.6)]
+        assert [(d.class_id, d.confidence) for d in raw] == [(14, 0.6), (0, 0.89)]
+
+    def test_floor_set_filtered_equivalent_to_no_floor(self):
+        """Post-filtered view with a floor == historical output without one."""
+        # What the model returns at the low floor (superset)
+        low_floor_boxes = [
+            (14, 0.6, (100, 100, 150, 150)),
+            (20, 0.2, (200, 200, 300, 300)),
+            (14, 0.3, (400, 400, 420, 420)),
+        ]
+        # What the model would have returned at conf=0.5 (historical call)
+        high_conf_boxes = [(14, 0.6, (100, 100, 150, 150))]
+
+        with_floor = self._detector(raw_floor_confidence=0.15)
+        with_floor._model = Mock(return_value=_mock_yolo_results(low_floor_boxes))
+
+        without_floor = self._detector()
+        without_floor._model = Mock(return_value=_mock_yolo_results(high_conf_boxes))
+
+        frame = _color_frame()
+        assert with_floor.detect(frame, timestamp=self.TS) == without_floor.detect(
+            frame, timestamp=self.TS
+        )
+
+    def test_ir_mode_threshold_switch_in_filtered_view(self):
+        """IR frames use confidence_threshold_ir for the filtered view, unchanged."""
+        detector = self._detector(confidence_threshold_ir=0.25, raw_floor_confidence=0.15)
+        model = Mock(
+            return_value=_mock_yolo_results(
+                [
+                    (14, 0.3, (100, 100, 150, 150)),  # above IR threshold -> filtered
+                    (14, 0.2, (200, 200, 250, 250)),  # below IR threshold -> raw only
+                ]
+            )
+        )
+        detector._model = model
+
+        filtered, raw = detector.detect_with_raw(_ir_frame(), timestamp=self.TS)
+
+        assert model.call_args.kwargs["conf"] == 0.15  # min(floor, IR threshold)
+        assert [(d.class_id, d.confidence) for d in filtered] == [(14, 0.3)]
+        assert [(d.class_id, d.confidence) for d in raw] == [(14, 0.3), (14, 0.2)]
+
+    def test_detect_and_detect_with_raw_agree(self):
+        """detect() and detect_with_raw()'s filtered view are the same list."""
+        boxes = [
+            (14, 0.6, (100, 100, 150, 150)),
+            (20, 0.2, (200, 200, 300, 300)),
+        ]
+        detector = self._detector(raw_floor_confidence=0.15)
+        detector._model = Mock(return_value=_mock_yolo_results(boxes))
+
+        frame = _color_frame()
+        filtered, _ = detector.detect_with_raw(frame, timestamp=self.TS)
+        assert detector.detect(frame, timestamp=self.TS) == filtered
+
+
 class TestFrame:
     """Tests for Frame dataclass."""
 


### PR DESCRIPTION
Part of the 024 series (ho-12 presence layer). Foundation for the PresenceTracker (024-B) and integration (024-C).

## What
- `FalconDetector.__init__` gains `raw_floor_confidence: float | None = None`. When `None`, behavior is exactly today's (model call at the effective threshold).
- New `detect_with_raw(frame, timestamp) -> (filtered, raw)`: one YOLO inference, two post-filtered views.
  - `filtered`: target classes at the effective threshold (IR-mode switch respected) — byte-identical to what `detect()`/`detect_birds()` return today.
  - `raw`: every box of every class at or above the floor (falls back to the effective threshold when unset). Harvard's at-lens "elephant @ 0.63" / "person @ 0.89" boxes survive here as presence evidence.
- When the floor is set, the model call runs at `min(raw_floor_confidence, effective_threshold)` and the filtered view is reconstructed in code. Exactly one inference per call.
- `detect()` / `detect_birds()` unchanged for existing callers, now implemented over the shared single-inference core.

## Tests
Mocked YOLO model (no ultralytics needed at test time): filtered/raw split, single-inference + min-conf model call, None-floor equivalence to current behavior, raw fallback to effective threshold, floor/no-floor filtered equivalence, IR-mode threshold switch, detect vs detect_with_raw agreement.

## Verification
- `black --check` / `isort --check` clean on touched files
- `mypy src/` clean
- `pytest`: 369 passed, 4 failed — the 4 known pre-existing failures on main (`test_detect_on_blank_frame`, 3x `TestShowContext`); zero new failures.

No buffer_monitor or presence.py changes — that is 024-B/024-C.