### PR TITLE
024-C: Wire presence layer into buffer monitor behind presence_enabled

### DIFF
--- a/configs/config.template.yaml
+++ b/configs/config.template.yaml
@@ -6,8 +6,9 @@
 # Every section below is documented with what the setting does, valid values,
 # and when you'd want to change it.
 #
-# TIMING CONSTRAINT (enforced at load):
+# TIMING CONSTRAINTS (enforced at load):
 #   roosting_threshold > exit_timeout
+#   presence_absence_failsafe_seconds > exit_timeout  (when presence_enabled)
 #
 # Thumbnail Image (for viewer landing page):
 #   Place a static thumbnail at:
@@ -105,6 +106,71 @@ timezone: "UTC"
 
 exit_timeout: 90
 roosting_threshold: 1800
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Presence Layer
+# ─────────────────────────────────────────────────────────────────────────────
+# Presence is a reasoned judgment over richer evidence, not a per-frame YOLO
+# bit. While a bird is present, presence is sustained by low-confidence
+# detections of ANY class overlapping the bird's region (an at-lens falcon
+# that YOLO calls "elephant" is still evidence of a bird) and by cheap motion
+# differencing inside the region. A motionless bird that YOLO stops seeing —
+# no detection, no motion — is exactly the signature of a sleeping bird and
+# stays PRESENT. Departure requires positive evidence: motion leaving the
+# region followed by quiet, after which the normal exit_timeout runs.
+#
+# Entering presence is unchanged: it still takes a full-confidence detection
+# (detection_confidence) plus the arrival confirmation window. The presence
+# layer only changes how presence is SUSTAINED and how departure is judged.
+#
+# presence_enabled — Master switch. false restores the legacy behavior
+#   exactly (presence = per-frame detection). Disable only to compare
+#   behavior or debug; the presence layer is the fix for false
+#   departed/arrived pairs on roosting birds.
+#
+# presence_sustain_confidence — Any-class confidence floor (0.0–1.0) for a
+#   detection box to sustain presence when it overlaps the bird's region.
+#   YOLO runs once per poll at this floor; full-confidence semantics for
+#   arrivals are reconstructed in code — no extra inference cost. Lower
+#   (e.g. 0.10) on Harvard-style cameras where birds walk up to the lens and
+#   misclassify badly; raise (e.g. 0.25) if unrelated objects near the nest
+#   keep presence alive too long.
+#
+# presence_region_margin_frac — The presence region is the last confirmed
+#   detection box expanded by this fraction of its size on each side
+#   (0.0–1.0). Larger margins tolerate more bird movement between polls but
+#   accept evidence from a wider area. 0.25 suits nest boxes; consider 0.5
+#   on wide scenes where the bird ranges within view.
+#
+# presence_motion_pixel_threshold — Per-pixel grayscale difference (0–255)
+#   between consecutive polls to count a pixel as "changed". Raise (e.g. 35)
+#   on noisy/low-light cameras that shimmer; lower (e.g. 15) on clean feeds
+#   where subtle movement should register.
+#
+# presence_motion_min_area_frac — Fraction of the region (0.0–1.0) that must
+#   change to count as motion. 0.02 catches a head turn on a mostly-still
+#   bird. Raise if wind-blown nest material reads as bird motion.
+#
+# presence_global_change_frac — If more than this fraction of the WHOLE frame
+#   changed (0.0–1.0), the poll's motion evidence is discarded entirely:
+#   IR/day flips, exposure swings, and camera adjustments must not read as
+#   bird motion or as departures. Raise toward 0.7 on cameras whose IR
+#   transition flickers repeatedly; lower toward 0.3 if genuine whole-scene
+#   changes are rare and you want stricter discounting.
+#
+# presence_absence_failsafe_seconds — Ceiling on a missed departure: zero
+#   evidence of any kind (no detection at any threshold, no motion) for this
+#   long forces absence, so presence can never be held forever. Must be
+#   greater than exit_timeout (enforced at load). Default 3600 (1 hour).
+
+presence_enabled: true
+presence_sustain_confidence: 0.15
+presence_region_margin_frac: 0.25
+presence_motion_pixel_threshold: 25
+presence_motion_min_area_frac: 0.02
+presence_global_change_frac: 0.5
+presence_absence_failsafe_seconds: 3600
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/src/kanyo/detection/buffer_monitor.py
+++ b/src/kanyo/detection/buffer_monitor.py
@@ -22,6 +22,7 @@ from kanyo.detection.event_handler import FalconEventHandler  # noqa: E402
 from kanyo.detection.event_types import FalconEvent  # noqa: E402
 from kanyo.detection.events import EventStore, FalconVisit  # noqa: E402
 from kanyo.detection.falcon_state import FalconStateMachine  # noqa: E402
+from kanyo.detection.presence import PresenceTracker  # noqa: E402
 from kanyo.utils.arrival_clip_recorder import ArrivalClipRecorder  # noqa: E402
 from kanyo.utils.config import get_now_tz, load_config  # noqa: E402
 from kanyo.utils.frame_buffer import FrameBuffer  # noqa: E402
@@ -92,6 +93,14 @@ class BufferMonitor:
         stream_recovery_threshold: int = 30,
         stream_recovery_confirmation: int = 10,
         stream_read_timeout_s: float = 10.0,
+        # Presence layer settings (ho-12 / 024-C)
+        presence_enabled: bool = True,
+        presence_sustain_confidence: float = 0.15,
+        presence_region_margin_frac: float = 0.25,
+        presence_motion_pixel_threshold: int = 25,
+        presence_motion_min_area_frac: float = 0.02,
+        presence_global_change_frac: float = 0.5,
+        presence_absence_failsafe_seconds: float = 3600.0,
         # Notification settings
         notify_on_startup: bool = True,
         record_arrival_on_startup: bool = False,
@@ -132,13 +141,40 @@ class BufferMonitor:
             now_fn=lambda: get_now_tz(self.full_config),
         )
 
-        # Detector
+        # Detector. With the presence layer enabled, the single inference per
+        # poll runs at the sustain floor so the tracker sees the raw
+        # (any-class, low-confidence) view; the filtered view keeps the
+        # historical detect_birds() semantics (024-A). Disabled, the detector
+        # is constructed exactly as before.
         self.detector = FalconDetector(
             confidence_threshold=confidence_threshold,
             confidence_threshold_ir=confidence_threshold_ir,
             detect_any_animal=detect_any_animal,
             animal_classes=animal_classes,
+            raw_floor_confidence=(presence_sustain_confidence if presence_enabled else None),
         )
+
+        # Presence layer (ho-12 / 024-C): sits between the detector and the
+        # state machine and decides the boolean the state machine consumes.
+        # None when disabled — the pipeline is then byte-identical to the
+        # pre-presence behavior (falcon_detected = len(detections) > 0).
+        self.presence: PresenceTracker | None = None
+        if presence_enabled:
+            self.presence = PresenceTracker(
+                sustain_confidence=presence_sustain_confidence,
+                region_margin_frac=presence_region_margin_frac,
+                motion_pixel_threshold=presence_motion_pixel_threshold,
+                motion_min_area_frac=presence_motion_min_area_frac,
+                global_change_frac=presence_global_change_frac,
+                absence_failsafe_seconds=presence_absence_failsafe_seconds,
+            )
+            # Semantic shift, logged once (ho-12): while present,
+            # last_detection_time / visit_end reflect presence evidence
+            # (sustain-level detections, region motion), not only YOLO hits.
+            logger.info(
+                "🔍 Presence layer ENABLED (ho-12): last_detection_time and visit_end "
+                "reflect presence evidence, not only YOLO hits"
+            )
 
         # Frame buffer for pre-arrival footage
         self.frame_buffer = FrameBuffer(
@@ -318,21 +354,47 @@ class BufferMonitor:
                         return  # skip YOLO this frame
                 self.last_roosting_check = now
 
-            # Run detection
-            detections = self.detector.detect_birds(frame_data, timestamp=now)
-            falcon_detected = len(detections) > 0
+            # Run detection — exactly ONE inference per poll (ho-12).
+            #
+            # Presence enabled: the same inference yields the raw (any-class,
+            # sustain-floor) view the tracker reasons over. `detections`
+            # stays the filtered view for everything that inspects
+            # confidences/boxes (peak tracking 022-A, summary 022-E,
+            # thumbnails); `falcon_detected` becomes the tracker's judgment —
+            # the boolean the state machine and visit lifetime consume.
+            #
+            # `yolo_detected` (filtered hits) keeps feeding the arrival/
+            # startup/recovery confirmation counters: ho-12 keeps ENTER
+            # exactly as strict as today ("feeding the existing arrival
+            # confirmation window unchanged"), and the recovery window must
+            # still be able to notice a bird that left during an outage —
+            # fed the presence boolean, a parked-sustain would make those
+            # windows vacuous.
+            if self.presence is not None:
+                detections, raw_detections = self.detector.detect_with_raw(
+                    frame_data, timestamp=now
+                )
+                yolo_detected = len(detections) > 0
+                falcon_detected = self.presence.update(frame_data, now, detections, raw_detections)
+            else:
+                # Legacy path — byte-identical to pre-presence behavior.
+                detections = self.detector.detect_birds(frame_data, timestamp=now)
+                yolo_detected = len(detections) > 0
+                falcon_detected = yolo_detected
 
-            # Track visit-scoped peak confidence (022-A)
+            # Track visit-scoped peak confidence (022-A) — keyed to filtered
+            # detections, never to presence evidence.
             self._frame_peak_confidence = max((d.confidence for d in detections), default=0.0)
-            if falcon_detected:
+            if yolo_detected:
                 self._visit_peak_confidence = max(
                     self._visit_peak_confidence, self._frame_peak_confidence
                 )
 
-            # Accumulate detection-confidence summary data (022-E)
+            # Accumulate detection-confidence summary data (022-E) — a YOLO
+            # threshold-tuning surface, so it counts filtered hits only.
             if self.detection_summary_interval > 0:
                 self._summary_poll_count += 1
-                if falcon_detected:
+                if yolo_detected:
                     self._summary_detected_confidences.append(self._frame_peak_confidence)
                 if time.time() - self._summary_window_start >= self.detection_summary_interval:
                     self._emit_detection_summary()
@@ -359,10 +421,12 @@ class BufferMonitor:
                         self._snapshot_departure_candidate(now)
                     self._roosting_last_poll_detected = False
 
-            # Startup confirmation logic (similar to arrival, but no telegram until confirmed)
+            # Startup confirmation logic (similar to arrival, but no telegram until confirmed).
+            # Counts filtered YOLO hits, not presence judgment — see the
+            # detection block above.
             if self.startup_pending and self.startup_pending_start is not None:
                 self.startup_frame_count += 1
-                if falcon_detected:
+                if yolo_detected:
                     self.startup_detection_count += 1
 
                 elapsed = (now - self.startup_pending_start).total_seconds()
@@ -375,11 +439,20 @@ class BufferMonitor:
                     else:
                         # FAILURE - not enough detections
                         self._cancel_startup_presence(ratio, now)
+                        # The tracker was just reset with the state machine;
+                        # the presence boolean computed at the top of this
+                        # frame is stale. Fall back to this frame's YOLO
+                        # evidence so a parked-sustain cannot instantly
+                        # re-arrive off a reset (ho-12 / 024-C). Disabled,
+                        # the two are already equal.
+                        falcon_detected = yolo_detected
 
-            # Arrival confirmation logic
+            # Arrival confirmation logic. Counts filtered YOLO hits, not
+            # presence judgment — ENTER semantics stay exactly as strict as
+            # today (ho-12).
             if self.arrival_pending and self.arrival_pending_start is not None:
                 self.arrival_frame_count += 1
-                if falcon_detected:
+                if yolo_detected:
                     self.arrival_detection_count += 1
 
                 elapsed = (now - self.arrival_pending_start).total_seconds()
@@ -392,11 +465,17 @@ class BufferMonitor:
                     else:
                         # FAILURE
                         self._cancel_arrival(ratio, now)
+                        # Stale presence boolean after a reset — see the
+                        # startup cancel above (ho-12 / 024-C).
+                        falcon_detected = yolo_detected
 
-            # Recovery confirmation logic (after stream outage)
+            # Recovery confirmation logic (after stream outage). Counts
+            # filtered YOLO hits, not presence judgment — the outage hid any
+            # exit motion from the tracker, so only fresh recognition can
+            # prove the bird is still there.
             if self.recovery_pending and self.recovery_pending_start is not None:
                 self.recovery_frame_count += 1
-                if falcon_detected:
+                if yolo_detected:
                     self.recovery_detection_count += 1
                     self.recovery_latest_detection = now
 
@@ -410,6 +489,9 @@ class BufferMonitor:
                     else:
                         # FAILURE - bird left during outage
                         self._cancel_recovery(ratio, now)
+                        # Stale presence boolean after a reset — see the
+                        # startup cancel above (ho-12 / 024-C).
+                        falcon_detected = yolo_detected
 
             # Debug logging for detection tracking
             if falcon_detected:
@@ -624,6 +706,12 @@ class BufferMonitor:
                 self._cancel_arrival(ratio, event_time)
                 return  # Do not process departure normally
 
+            # The visit is over — the tracker's presence episode ends with it,
+            # so the next presence can only begin with a strict ENTER
+            # (ho-12 / 024-C). Without this, a stale episode could flip back
+            # to "present" on region motion alone after the departure.
+            self._reset_presence()
+
             # Stop arrival clip if still active (short visit may not have hit its time limit)
             if self.arrival_clip_recorder.is_recording():
                 self.arrival_clip_recorder.stop_recording(event_time)
@@ -829,6 +917,9 @@ class BufferMonitor:
         # Reset state machine to ABSENT
         self.state_machine.reset_to_absent()
 
+        # Tracker resets with the state machine (ho-12 / 024-C)
+        self._reset_presence()
+
         # Cancelled visit — discard its peak confidence (022-A)
         self._visit_peak_confidence = 0.0
 
@@ -961,6 +1052,9 @@ class BufferMonitor:
         # Get departure events from state machine (uses last_detection from before outage)
         events = self.state_machine.cancel_recovery(now)
 
+        # Tracker resets with the state machine (ho-12 / 024-C)
+        self._reset_presence()
+
         # Handle deparure event (create clips, notify, etc.)
         for event_type, event_time, metadata in events:
             self.event_handler.handle_event(event_type, event_time, metadata)
@@ -973,11 +1067,26 @@ class BufferMonitor:
         self.recovery_frame_count = 0
         self.recovery_latest_detection = None
 
+    def _reset_presence(self) -> None:
+        """Reset the presence tracker so it cannot disagree with the state machine.
+
+        Called wherever the state machine is force-reset (cancelled arrival,
+        cancelled startup, cancelled recovery, outage-exceeded) and on a real
+        DEPARTED — the tracker's episode ends with the visit, so a new
+        presence can only begin with a strict ENTER (filtered detection).
+        No-op when the presence layer is disabled (ho-12 / 024-C).
+        """
+        if self.presence is not None:
+            self.presence.reset()
+
     def _reset_pending_states(self) -> None:
         """Reset all pending confirmation states (startup, arrival, and recovery)."""
         # Any visit in progress is being abandoned (cancelled startup or
         # outage-exceeded reset) — discard its peak confidence (022-A)
         self._visit_peak_confidence = 0.0
+
+        # Tracker and state machine reset together (ho-12 / 024-C)
+        self._reset_presence()
 
         self.startup_pending = False
         self.startup_pending_start = None
@@ -1168,6 +1277,18 @@ class BufferMonitor:
 
                             # Seed the visit peak from startup init detections (022-A)
                             self._visit_peak_confidence = max_conf
+
+                            # Seed the presence tracker from the startup
+                            # detections on entering PENDING_STARTUP
+                            # (ho-12 / 024-C): the episode begins with a
+                            # region from the best startup bbox and this
+                            # frame as the motion baseline. The init loop
+                            # itself stays on plain detection — no presence
+                            # judgment before the state machine initializes.
+                            if self.presence is not None:
+                                self.presence.update(
+                                    frame.data, now, initial_detections, initial_detections
+                                )
 
                             # If falcon detected, state is PENDING_STARTUP
                             # We need to confirm presence before transitioning to ROOSTING
@@ -1400,6 +1521,13 @@ def main():
             stream_recovery_threshold=config.get("stream_recovery_threshold", 30),
             stream_recovery_confirmation=config.get("stream_recovery_confirmation", 10),
             stream_read_timeout_s=config.get("stream_read_timeout_s", 10.0),
+            presence_enabled=config.get("presence_enabled", True),
+            presence_sustain_confidence=config.get("presence_sustain_confidence", 0.15),
+            presence_region_margin_frac=config.get("presence_region_margin_frac", 0.25),
+            presence_motion_pixel_threshold=config.get("presence_motion_pixel_threshold", 25),
+            presence_motion_min_area_frac=config.get("presence_motion_min_area_frac", 0.02),
+            presence_global_change_frac=config.get("presence_global_change_frac", 0.5),
+            presence_absence_failsafe_seconds=config.get("presence_absence_failsafe_seconds", 3600),
             notify_on_startup=config.get("notify_on_startup", True),
             record_arrival_on_startup=config.get("record_arrival_on_startup", False),
             max_runtime_seconds=config.get("max_runtime_seconds"),

--- a/src/kanyo/utils/config.py
+++ b/src/kanyo/utils/config.py
@@ -41,6 +41,14 @@ DEFAULTS: dict[str, Any] = {
     "arrival_confirmation_seconds": 10,  # Time window to confirm arrival
     "arrival_confirmation_ratio": 0.3,  # Fraction of frames that must detect
     "record_arrival_on_startup": False,  # Record arrival clip when bird present at startup
+    # Presence Layer (ho-12)
+    "presence_enabled": True,  # presence layer on/off (off = legacy per-frame behavior)
+    "presence_sustain_confidence": 0.15,  # any-class floor to sustain presence in region
+    "presence_region_margin_frac": 0.25,  # region = last bbox + this fraction of bbox size
+    "presence_motion_pixel_threshold": 25,  # grayscale absdiff threshold per pixel
+    "presence_motion_min_area_frac": 0.02,  # changed fraction of region to count as motion
+    "presence_global_change_frac": 0.5,  # whole-frame change above this = discard motion evidence
+    "presence_absence_failsafe_seconds": 3600,  # zero-evidence ceiling before forced absence
     # Output & Storage
     "output_dir": "output",  # results directory
     "data_dir": "data",  # thumbnails, events, etc.
@@ -275,6 +283,35 @@ def _validate(cfg: dict[str, Any]) -> None:
             f"short_visit_threshold ({short_visit_threshold}s) is too short. "
             f"Minimum recommended value is 60 seconds."
         )
+
+    # Presence layer validation (ho-12 / 024-C)
+    presence_fraction_keys = (
+        "presence_sustain_confidence",
+        "presence_region_margin_frac",
+        "presence_motion_min_area_frac",
+        "presence_global_change_frac",
+    )
+    for key in presence_fraction_keys:
+        value = cfg.get(key, DEFAULTS[key])
+        if not isinstance(value, (int, float)) or not 0.0 <= value <= 1.0:
+            raise ValueError(f"{key} must be between 0.0 and 1.0")
+
+    pixel_threshold = cfg.get("presence_motion_pixel_threshold", 25)
+    if not isinstance(pixel_threshold, (int, float)) or not 0 <= pixel_threshold <= 255:
+        raise ValueError("presence_motion_pixel_threshold must be between 0 and 255")
+
+    # The failsafe is the ceiling on a missed departure; the state machine's
+    # exit_timeout debounces below it. A failsafe at or under exit_timeout
+    # would let the failsafe race the debounce. Only enforced when the
+    # presence layer is on — disabled, the key is inert and must not block
+    # an otherwise-valid legacy config.
+    if cfg.get("presence_enabled", DEFAULTS["presence_enabled"]):
+        failsafe = cfg.get("presence_absence_failsafe_seconds", 3600)
+        if not isinstance(failsafe, (int, float)) or failsafe <= exit_timeout:
+            raise ValueError(
+                f"presence_absence_failsafe_seconds ({failsafe}) must be greater than "
+                f"exit_timeout ({exit_timeout}s)"
+            )
 
     # stream_read_timeout_s sanity (ho-11)
     read_timeout = cfg.get("stream_read_timeout_s", 10.0)

--- a/tests/test_detection_summary.py
+++ b/tests/test_detection_summary.py
@@ -30,6 +30,10 @@ def make_monitor(detection_summary_interval: int = 300):
         monitor = BufferMonitor(
             stream_url="test",
             detection_summary_interval=detection_summary_interval,
+            # Legacy-path fixture (mocked detect_birds, MagicMock frames);
+            # the presence-enabled path is covered by
+            # test_presence_integration.py (024-C).
+            presence_enabled=False,
         )
     monitor.visit_recorder.is_recording = False
     monitor.arrival_clip_recorder.is_recording.return_value = False

--- a/tests/test_frame_timestamp_authority.py
+++ b/tests/test_frame_timestamp_authority.py
@@ -29,7 +29,10 @@ def make_monitor(**kwargs):
         patch("kanyo.detection.buffer_monitor.FalconStateMachine"),
         patch("kanyo.detection.buffer_monitor.ArrivalClipRecorder"),
     ):
-        monitor = BufferMonitor(stream_url="test", **kwargs)
+        # Legacy-path fixture (mocked detect_birds, MagicMock frames); the
+        # presence-enabled path is covered by test_presence_integration.py
+        # (024-C).
+        monitor = BufferMonitor(stream_url="test", presence_enabled=False, **kwargs)
     _quiet_frame_mocks(monitor)
     return monitor
 

--- a/tests/test_presence_integration.py
+++ b/tests/test_presence_integration.py
@@ -1,0 +1,431 @@
+"""Integration tests for the presence layer wiring in BufferMonitor (024-C).
+
+Drives BufferMonitor.process_frame with a mocked detector and synthetic
+numpy frames, with the real PresenceTracker and FalconStateMachine in the
+loop. Recording/clip components are mocked — event sequences and
+confirmation counters are what's under test, not recording mechanics.
+"""
+
+from datetime import datetime, timedelta
+from unittest.mock import Mock
+
+import numpy as np
+import pytest
+
+from kanyo.detection.buffer_monitor import BufferMonitor
+from kanyo.detection.detect import Detection
+from kanyo.detection.event_types import FalconEvent
+from kanyo.detection.presence import PresenceTracker
+
+FRAME_H = 240
+FRAME_W = 320
+BLOB = (100, 100, 140, 140)
+T0 = datetime(2026, 7, 16, 12, 0, 0)
+
+EXIT_TIMEOUT = 90
+CONFIRMATION_SECONDS = 4
+CONFIRMATION_RATIO = 0.5
+
+
+def ts(seconds: float) -> datetime:
+    return T0 + timedelta(seconds=seconds)
+
+
+def make_frame(blob: tuple[int, int, int, int] | None = BLOB) -> np.ndarray:
+    """Dark frame with an optional bright rectangular blob (x1, y1, x2, y2)."""
+    frame = np.zeros((FRAME_H, FRAME_W, 3), dtype=np.uint8)
+    if blob is not None:
+        x1, y1, x2, y2 = blob
+        frame[y1:y2, x1:x2] = 200
+    return frame
+
+
+def bird(confidence: float, when: datetime) -> Detection:
+    return Detection(
+        class_id=14, class_name="bird", confidence=confidence, bbox=BLOB, timestamp=when
+    )
+
+
+def make_monitor(presence_enabled: bool) -> BufferMonitor:
+    """BufferMonitor with mocked detector/recording components and a real
+    state machine (and real PresenceTracker when enabled)."""
+    monitor = BufferMonitor(
+        stream_url="test",
+        exit_timeout_seconds=EXIT_TIMEOUT,
+        presence_enabled=presence_enabled,
+        full_config={
+            "arrival_confirmation_seconds": CONFIRMATION_SECONDS,
+            "arrival_confirmation_ratio": CONFIRMATION_RATIO,
+        },
+    )
+
+    # Detector is scripted per frame via drive().
+    monitor.detector = Mock()
+
+    # Recording/clip components are not under test.
+    monitor.visit_recorder = Mock()
+    monitor.visit_recorder.is_recording = False
+    monitor.visit_recorder.stream_outage_exceeded = False
+    monitor.visit_recorder.lead_in_seconds = 15
+    monitor.visit_recorder.stop_recording.return_value = (None, None)
+    monitor.visit_recorder.get_temp_path.return_value = None
+
+    monitor.arrival_clip_recorder = Mock()
+    monitor.arrival_clip_recorder.is_recording.return_value = False
+    monitor.arrival_clip_recorder.get_temp_path.return_value = None
+
+    monitor.event_handler = Mock()
+    monitor.clip_manager = Mock()
+    monitor.clip_manager.clip_departure_before = 30
+    monitor.clip_manager.create_departure_clip.return_value = False
+
+    # Exit initialization mode so ARRIVED events fire.
+    monitor.state_machine.initializing = False
+
+    return monitor
+
+
+def spy_events(monitor: BufferMonitor) -> list[FalconEvent]:
+    """Record every event type routed through _handle_event, in order."""
+    events: list[FalconEvent] = []
+    original = monitor._handle_event
+
+    def recording_handler(event_type, event_time, metadata):
+        events.append(event_type)
+        original(event_type, event_time, metadata)
+
+    monitor._handle_event = recording_handler  # type: ignore[method-assign]  # test spy
+    return events
+
+
+def drive(
+    monitor: BufferMonitor,
+    frame: np.ndarray,
+    when: datetime,
+    filtered: list[Detection],
+    raw: list[Detection] | None = None,
+) -> None:
+    """Process one frame with scripted detector output."""
+    raw = filtered if raw is None else raw
+    monitor.detector.detect_with_raw.return_value = (filtered, raw)
+    monitor.detector.detect_birds.return_value = filtered
+    monitor.process_frame(frame, 0, when)
+
+
+def arrive_and_confirm(monitor: BufferMonitor) -> float:
+    """Drive a clean arrival through the confirmation window on static blob
+    frames. Returns the timestamp offset (seconds) of the last driven frame."""
+    frame = make_frame(BLOB)
+    t = 0.0
+    drive(monitor, frame, ts(t), [bird(0.8, ts(t))])  # ARRIVED
+    while monitor.arrival_pending:
+        t += 1.0
+        drive(monitor, frame, ts(t), [bird(0.8, ts(t))])
+    return t
+
+
+class TestConstruction:
+    """Constructor wiring behind presence_enabled."""
+
+    def test_enabled_builds_tracker_and_raw_floor(self):
+        monitor = BufferMonitor(
+            stream_url="test",
+            presence_enabled=True,
+            presence_sustain_confidence=0.2,
+            presence_region_margin_frac=0.3,
+            presence_motion_pixel_threshold=30,
+            presence_motion_min_area_frac=0.05,
+            presence_global_change_frac=0.6,
+            presence_absence_failsafe_seconds=7200,
+        )
+        assert isinstance(monitor.presence, PresenceTracker)
+        assert monitor.detector.raw_floor_confidence == 0.2
+        assert monitor.presence.sustain_confidence == 0.2
+        assert monitor.presence.region_margin_frac == 0.3
+        assert monitor.presence.motion_pixel_threshold == 30
+        assert monitor.presence.motion_min_area_frac == 0.05
+        assert monitor.presence.global_change_frac == 0.6
+        assert monitor.presence.absence_failsafe_seconds == 7200
+
+    def test_enabled_by_default(self):
+        monitor = BufferMonitor(stream_url="test")
+        assert isinstance(monitor.presence, PresenceTracker)
+
+    def test_disabled_builds_no_tracker_no_raw_floor(self):
+        monitor = BufferMonitor(stream_url="test", presence_enabled=False)
+        assert monitor.presence is None
+        assert monitor.detector.raw_floor_confidence is None
+
+
+class TestDisabledLegacyBehavior:
+    """presence_enabled: false must reproduce the pre-presence pipeline."""
+
+    def test_dropout_manufactures_departed_as_today(self):
+        """The legacy event sequence for 'arrival, dropout past exit_timeout':
+        ARRIVED then DEPARTED — the manufactured exit the presence layer
+        exists to fix stays intact when the layer is off."""
+        monitor = make_monitor(presence_enabled=False)
+        events = spy_events(monitor)
+
+        t = arrive_and_confirm(monitor)
+        assert events == [FalconEvent.ARRIVED]
+
+        # Detection dropout on a static frame — legacy behavior departs.
+        frame = make_frame(BLOB)
+        end = t + EXIT_TIMEOUT + 20
+        while t < end:
+            t += 5.0
+            drive(monitor, frame, ts(t), [])
+
+        assert FalconEvent.DEPARTED in events
+        assert monitor.state_machine.state.value == "absent"
+
+    def test_disabled_never_calls_detect_with_raw(self):
+        monitor = make_monitor(presence_enabled=False)
+        drive(monitor, make_frame(BLOB), ts(0), [bird(0.8, ts(0))])
+        drive(monitor, make_frame(BLOB), ts(1), [])
+
+        monitor.detector.detect_birds.assert_called()
+        monitor.detector.detect_with_raw.assert_not_called()
+
+
+class TestEnabledSustain:
+    """The core fix: detection dropout on a parked bird must not depart."""
+
+    def test_dropout_on_parked_frame_produces_no_departed(self):
+        monitor = make_monitor(presence_enabled=True)
+        events = spy_events(monitor)
+
+        t = arrive_and_confirm(monitor)
+        assert events == [FalconEvent.ARRIVED]
+
+        # Total detection dropout, static (parked) frame, far past
+        # exit_timeout: no detection AND no motion = still present.
+        frame = make_frame(BLOB)
+        end = t + EXIT_TIMEOUT * 3
+        while t < end:
+            t += 5.0
+            drive(monitor, frame, ts(t), [], [])
+
+        assert FalconEvent.DEPARTED not in events
+        assert monitor.state_machine.state.value == "visiting"
+
+    def test_sustain_keeps_last_detection_time_current(self):
+        """With presence enabled, last_detection_time reflects presence
+        evidence — intended semantic shift (ho-12)."""
+        monitor = make_monitor(presence_enabled=True)
+        t = arrive_and_confirm(monitor)
+
+        frame = make_frame(BLOB)
+        t += 30.0
+        drive(monitor, frame, ts(t), [], [])
+        assert monitor.last_detection_time == ts(t)
+
+
+class TestEnabledDeparture:
+    """Exit still works: motion out of the region then quiet allows the
+    normal exit_timeout departure."""
+
+    def test_motion_out_then_quiet_departs(self):
+        monitor = make_monitor(presence_enabled=True)
+        events = spy_events(monitor)
+
+        t = arrive_and_confirm(monitor)
+
+        # Motion burst: the blob vanishes (bird leaves). One poll of region
+        # motion, then a quiet empty nest with no detections at any level.
+        empty = make_frame(None)
+        t += 5.0
+        drive(monitor, empty, ts(t), [], [])
+
+        end = t + EXIT_TIMEOUT + 30
+        while t < end:
+            t += 5.0
+            drive(monitor, empty, ts(t), [], [])
+
+        assert FalconEvent.DEPARTED in events
+        assert monitor.state_machine.state.value == "absent"
+
+    def test_departed_resets_tracker_episode(self):
+        """After DEPARTED the tracker's episode is closed: a new presence can
+        only begin with a strict ENTER (filtered detection)."""
+        monitor = make_monitor(presence_enabled=True)
+        events = spy_events(monitor)
+
+        t = arrive_and_confirm(monitor)
+        empty = make_frame(None)
+        end = t + EXIT_TIMEOUT + 40
+        while t < end:
+            t += 5.0
+            drive(monitor, empty, ts(t), [], [])
+        assert FalconEvent.DEPARTED in events
+
+        assert monitor.presence is not None
+        assert monitor.presence.state_info()["episode_active"] is False
+
+
+class TestEnterSemantics:
+    """Arrival confirmation stays keyed to filtered YOLO hits (ENTER path
+    unchanged), in both modes."""
+
+    def test_clean_arrival_counters_identical_in_both_modes(self):
+        frame = make_frame(BLOB)
+        script: list[list[Detection]] = [
+            [bird(0.8, ts(0))],  # ARRIVED
+            [bird(0.7, ts(1))],
+            [],  # recognition gap inside the window
+            [bird(0.9, ts(3))],
+        ]
+
+        counts = {}
+        for enabled in (True, False):
+            monitor = make_monitor(presence_enabled=enabled)
+            for i, filtered in enumerate(script):
+                drive(monitor, frame, ts(i), filtered)
+            counts[enabled] = (
+                monitor.arrival_detection_count,
+                monitor.arrival_frame_count,
+            )
+
+        # Seeded 1/1 by ARRIVED, then +det, +miss, +det → 3/4 in both modes.
+        assert counts[True] == counts[False] == (3, 4)
+
+    def test_parked_sustain_does_not_rescue_failed_confirmation(self):
+        """A single-frame ENTER followed by nothing but parked-sustain must
+        still fail confirmation — the counters count YOLO hits, not the
+        presence boolean — and the cancel resets the tracker."""
+        monitor = make_monitor(presence_enabled=True)
+        frame = make_frame(BLOB)
+
+        drive(monitor, frame, ts(0), [bird(0.8, ts(0))])  # ARRIVED
+        assert monitor.arrival_pending is True
+
+        # No detections at all; the parked frame sustains presence, so the
+        # state machine keeps seeing True — but the confirmation ratio
+        # collapses: 1 hit / 6 frames < 0.5.
+        t = 0.0
+        while monitor.arrival_pending:
+            t += 1.0
+            drive(monitor, frame, ts(t), [], [])
+
+        assert monitor.state_machine.state.value == "absent"
+        assert monitor.presence is not None
+        assert monitor.presence.state_info()["episode_active"] is False
+
+
+class TestResetHooks:
+    """Tracker and state machine cannot disagree after a force-reset."""
+
+    def _present_monitor(self) -> BufferMonitor:
+        monitor = make_monitor(presence_enabled=True)
+        arrive_and_confirm(monitor)
+        assert monitor.presence is not None
+        assert monitor.presence.state_info()["episode_active"] is True
+        return monitor
+
+    def test_reset_pending_states_resets_tracker(self):
+        """Covers the outage-exceeded paths and cancelled startup, which all
+        flow through _reset_pending_states."""
+        monitor = self._present_monitor()
+        monitor._reset_pending_states()
+        assert monitor.presence.state_info()["episode_active"] is False
+
+    def test_cancel_recovery_resets_tracker(self):
+        monitor = self._present_monitor()
+        events = spy_events(monitor)
+
+        monitor.state_machine.set_pending_recovery(ts(100))
+        monitor._cancel_recovery(0.0, ts(120))
+
+        assert FalconEvent.DEPARTED in events
+        assert monitor.presence.state_info()["episode_active"] is False
+        assert monitor.state_machine.state.value == "absent"
+
+    def test_disabled_reset_is_noop(self):
+        monitor = make_monitor(presence_enabled=False)
+        monitor._reset_presence()  # must not raise with presence=None
+        monitor._reset_pending_states()
+
+
+class TestPresenceConfig:
+    """Config keys, defaults, and validation (024-C)."""
+
+    def test_defaults_contain_all_presence_keys(self):
+        from kanyo.utils.config import DEFAULTS
+
+        assert DEFAULTS["presence_enabled"] is True
+        assert DEFAULTS["presence_sustain_confidence"] == 0.15
+        assert DEFAULTS["presence_region_margin_frac"] == 0.25
+        assert DEFAULTS["presence_motion_pixel_threshold"] == 25
+        assert DEFAULTS["presence_motion_min_area_frac"] == 0.02
+        assert DEFAULTS["presence_global_change_frac"] == 0.5
+        assert DEFAULTS["presence_absence_failsafe_seconds"] == 3600
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "presence_sustain_confidence",
+            "presence_region_margin_frac",
+            "presence_motion_min_area_frac",
+            "presence_global_change_frac",
+        ],
+    )
+    @pytest.mark.parametrize("bad_value", [-0.1, 1.5, "high"])
+    def test_fraction_out_of_range_rejected(self, key, bad_value):
+        from kanyo.utils.config import _validate
+
+        cfg = {"video_source": "https://youtube.com/test", key: bad_value}
+        with pytest.raises(ValueError, match=f"{key} must be between 0.0 and 1.0"):
+            _validate(cfg)
+
+    @pytest.mark.parametrize("bad_value", [-1, 256])
+    def test_pixel_threshold_out_of_range_rejected(self, bad_value):
+        from kanyo.utils.config import _validate
+
+        cfg = {
+            "video_source": "https://youtube.com/test",
+            "presence_motion_pixel_threshold": bad_value,
+        }
+        with pytest.raises(ValueError, match="presence_motion_pixel_threshold"):
+            _validate(cfg)
+
+    def test_failsafe_must_exceed_exit_timeout(self):
+        from kanyo.utils.config import _validate
+
+        cfg = {
+            "video_source": "https://youtube.com/test",
+            "exit_timeout": 300,
+            "roosting_threshold": 1800,
+            "presence_absence_failsafe_seconds": 300,
+        }
+        with pytest.raises(ValueError, match="presence_absence_failsafe_seconds"):
+            _validate(cfg)
+
+    def test_failsafe_constraint_inert_when_disabled(self):
+        """With the presence layer off the failsafe key is unused and must
+        not block an otherwise-valid legacy config."""
+        from kanyo.utils.config import _validate
+
+        cfg = {
+            "video_source": "https://youtube.com/test",
+            "exit_timeout": 300,
+            "roosting_threshold": 1800,
+            "presence_enabled": False,
+            "presence_absence_failsafe_seconds": 300,
+        }
+        _validate(cfg)  # should not raise
+
+    def test_valid_presence_config_passes(self):
+        from kanyo.utils.config import _validate
+
+        cfg = {
+            "video_source": "https://youtube.com/test",
+            "presence_enabled": True,
+            "presence_sustain_confidence": 0.1,
+            "presence_region_margin_frac": 0.5,
+            "presence_motion_pixel_threshold": 35,
+            "presence_motion_min_area_frac": 0.05,
+            "presence_global_change_frac": 0.7,
+            "presence_absence_failsafe_seconds": 1800,
+        }
+        _validate(cfg)  # should not raise

--- a/tests/test_roosting_departure_candidate.py
+++ b/tests/test_roosting_departure_candidate.py
@@ -33,6 +33,10 @@ def make_monitor(clips_dir: str = "clips"):
         monitor = BufferMonitor(
             stream_url="test",
             clips_dir=clips_dir,
+            # Legacy-path fixture (mocked detect_birds, MagicMock frames);
+            # the presence-enabled path is covered by
+            # test_presence_integration.py (024-C).
+            presence_enabled=False,
             full_config={
                 "roosting_recording_mode": "stop",
                 "roosting_detection_interval": 30,

--- a/tests/test_roosting_mode.py
+++ b/tests/test_roosting_mode.py
@@ -24,6 +24,10 @@ def make_monitor(roosting_recording_mode: str = "stop", roosting_detection_inter
     ):
         monitor = BufferMonitor(
             stream_url="test",
+            # Legacy-path fixture (mocked detect_birds, MagicMock frames);
+            # the presence-enabled path is covered by
+            # test_presence_integration.py (024-C).
+            presence_enabled=False,
             full_config={
                 "roosting_recording_mode": roosting_recording_mode,
                 "roosting_detection_interval": roosting_detection_interval,

--- a/tests/test_visit_record_fields.py
+++ b/tests/test_visit_record_fields.py
@@ -31,6 +31,10 @@ def make_monitor(clips_dir: str = "clips", roosting_recording_mode: str = "conti
         monitor = BufferMonitor(
             stream_url="test",
             clips_dir=clips_dir,
+            # Legacy-path fixture (mocked detect_birds, MagicMock frames);
+            # the presence-enabled path is covered by
+            # test_presence_integration.py (024-C).
+            presence_enabled=False,
             full_config={
                 "roosting_recording_mode": roosting_recording_mode,
                 "roosting_detection_interval": 30,


### PR DESCRIPTION
Closes out the 024 series (ho-12): `PresenceTracker` (#39) now sits between the detector (#38) and the state machine in `buffer_monitor`, deciding the boolean the state machine consumes. With `presence_enabled: false` the pipeline is byte-identical to current behavior.

## Wiring

- `BufferMonitor` builds the detector with `raw_floor_confidence` at the sustain floor and constructs a `PresenceTracker` when `presence_enabled` (default true). One inference per poll: `detect_with_raw` yields the filtered view (everything that inspects confidences/boxes — 022-A peak tracking, 022-E summary) and the raw view the tracker reasons over.
- The presence judgment feeds the state machine and visit lifetime (`last_detection_time` / `visit_end` now reflect presence evidence — intended semantic shift per ho-12, logged once at startup).
- **Confirmation counters (arrival/startup/recovery) keep counting filtered YOLO hits.** ho-12 keeps ENTER exactly as strict as today, and the recovery window must still catch a bird that left during an outage — fed the presence boolean, a parked-sustain would make those windows vacuous.
- Reset hooks: the tracker resets with every state-machine force-reset (cancelled arrival/startup/recovery, outage-exceeded) **and on DEPARTED** — without the latter, a stale episode could flip back to present on region motion alone, bypassing strict ENTER.
- After a cancelled confirmation, the frame's stale presence boolean is downgraded to that frame's YOLO evidence so a parked-sustain cannot instantly re-arrive off a reset (matches legacy cancel-frame semantics exactly).
- `run()` init loop stays on plain detection; the tracker is seeded from startup detections on entering PENDING_STARTUP.

## Config

Seven `presence_*` keys in `DEFAULTS` with validation (fractions in [0,1], pixel threshold 0–255, failsafe > `exit_timeout` — the cross-constraint only enforced when the layer is enabled, so a disabled key can't block a legacy config), plus a documented Presence Layer section in `config.template.yaml` with per-key tuning guidance (at-lens cams, flappy IR cams).

## Tests

New `tests/test_presence_integration.py` (32 tests): parked-frame detection dropout produces no DEPARTED past exit_timeout; motion-out then quiet still departs; disabled mode reproduces the legacy event sequence (manufactured exit intact) and never calls `detect_with_raw`; confirmation counters identical in both modes; failed confirmation not rescued by parked-sustain; reset hooks; config validation. Five legacy-path test fixtures (mocked `detect_birds`, MagicMock frames) pin `presence_enabled=false` — the enabled path is covered by the new integration tests.

Verification: `black`/`isort` clean on touched files, `mypy src/` clean, 416 passed / 4 known pre-existing failures (test_detect_on_blank_frame + 3 TestShowContext).