### PR TITLE
025-A: Add EventSignificanceFilter - merge window, minimum significance, activity damping

### DIFF
--- a/devlog/ho-09-significance-filter.md
+++ b/devlog/ho-09-significance-filter.md
@@ -1,8 +1,10 @@
 # Ho-09 — Significance Filter: Event Merging and Behavioral Significance
 
-**Status:** Scaffold — awaiting authoring session  
-**Preceded by:** ho-08 (zombie ffmpeg fix)  
-**Motivating incident:** 2026-06-19 Fort Wayne nest swap storm; 788 clips, 27 zombie ffmpegs, machine in swap
+**Date authored:** 2026-07-16 (scaffolded post-ho-08; open questions now decidable)
+**Status:** 📋 AUTHORED — ready for execution, **sequenced AFTER ho-12**
+**Preceded by:** ho-08 (zombie ffmpeg fix); executes after ho-10/ho-11/ho-12
+**Motivating incidents:** 2026-06-19 Fort Wayne nest swap storm (788 clips, 27 zombie ffmpegs, machine in swap); July 2026 UMass 1,350 events with median visit 19s
+**Agent task series:** 025 (see `Agent-Tasks/025-significance-filter.md`)
 
 ---
 
@@ -10,86 +12,165 @@
 
 YOLO answers one question: *is there a bird in this frame?*
 
-Kanyō currently treats every ARRIVED/DEPARTED pair as a significant event. During active nesting — incubation swaps, brooding shifts, adults trading nest duty — the state machine fires dozens of arrivals and departures per day that are biologically routine and operationally noisy. The machine runs hot, clips accumulate, and the viewer sees nothing but motion.
+Kanyō currently treats every ARRIVED/DEPARTED pair as a significant event.
+During active nesting — incubation swaps, brooding shifts, adults trading
+nest duty — the state machine fires dozens of arrivals and departures per day
+that are biologically routine and operationally noisy. The machine runs hot,
+clips accumulate, and the viewer sees nothing but motion.
 
-The user's framing: **"I don't care if birds are coming and going. I care if something interesting is happening."**
+The user's framing: **"I don't care if birds are coming and going. I care if
+something interesting is happening."**
 
-YOLO has met its match on nest cams. The detection substrate is fine. The significance reasoning is missing.
+The detection substrate is fine. The significance reasoning is missing.
+
+**Sequencing note:** ho-12's presence layer removes the *manufactured* churn
+(recognition gaps on roosting birds). What remains after ho-12 is *real*
+churn — genuine short visits, genuine rapid swaps. This ho is the safety net
+for that residual, and it is deliberately sequenced after ho-12 so it filters
+real behavior, not recognition noise. Do not execute this ho before the 024
+series is deployed and observed.
 
 ---
 
 ## What this ho is NOT
 
-- Not an LLM/VLM feature. Significance filtering at this level is purely temporal and algorithmic.
-- Not a YOLO replacement. YOLO stays as the per-frame detection substrate.
+- Not an LLM/VLM feature. Significance filtering at this level is purely
+  temporal and algorithmic.
+- Not a YOLO replacement. YOLO (behind ho-12's presence layer) stays as the
+  detection substrate.
 - Not a model training session (that is ho-07).
-- The VLM "what is happening here?" capability is a future ho (ho-10 or later) that layers on top of this one.
+- Not a state machine change. The state machine stays pure — it reports what
+  happened; the filter decides what it means.
 
 ---
 
-## Core concepts to design
+## Decisions (resolving the scaffold's open questions)
 
-### 1. Event merge window
+### Architecture: a distinct `EventSignificanceFilter`
 
-If DEPARTED → ARRIVED fires within N minutes, treat it as a **continuous event** (or a named `SWAP` event) rather than two separate events. No new clip. No new notification. The existing visit extends or is flagged.
+Of the three options the scaffold named (state machine / `_handle_event` /
+new layer), the answer is a **new class `EventSignificanceFilter` in
+`src/kanyo/detection/significance_filter.py`**, sitting between state-machine
+events and `event_handler`/notifications in `buffer_monitor`. The state
+machine knows nothing about significance; `_handle_event`'s recording
+mechanics (start/stop recorder, clip extraction) run on raw events exactly as
+today. What the filter governs is the *surface*: notifications, event-store
+rows, and which clips are kept and referenced.
 
-Key decisions:
-- What is N? (Per-cam config. Fort Wayne nesting season: aggressive. Harvard normal: conservative.)
-- Does a swap extend the existing visit recording, or start a new one silently?
-- Does the merge window reset on each swap, or is there a maximum merged visit duration?
+This mirrors ho-12's move: the state machine stays a pure presence machine;
+judgment layers sit beside it, each with one job.
 
-### 2. Minimum visit significance
+### SWAP event vs silent merge: merge, flagged
 
-Visits with detection duration below M seconds are **logged only** — no clip, no notification, no full recording pipeline triggered. M is configurable per cam.
+No new event type. A DEPARTED→ARRIVED pair inside the merge window is a
+*continuation of the same visit*: the merged `FalconVisit` row spans both
+segments and carries a `merged_segments` count, so the viewer can render a
+swap differently if it wants — but the event vocabulary (ARRIVED, DEPARTED,
+ROOSTING) does not grow. A SWAP event would push behavioral interpretation
+into the event layer, which is exactly what this ho keeps out of it.
 
-Key decisions:
-- What counts as "detection duration"? (Time between first and last YOLO hit, not wall-clock visit duration including exit_timeout.)
-- Does the clip still get made but not surfaced? Or does recording not start at all?
+### Merge window mechanics
 
-### 3. Activity-rate damping
+When DEPARTED fires, the filter **holds** its surface effects (departure
+notification, event-store append) for `merge_window_seconds` (default 300).
 
-If more than N ARRIVED events fire in the last H hours, the cam enters **busy mode**: notifications suppressed, recording continues, clips are made but flagged as routine. Busy mode resets when the rate drops.
+- **ARRIVED within the window** → continuation. No new notification, no new
+  arrival clip surfaced (the continuation's arrival clip file is discarded),
+  the held visit stays open, `merged_segments` increments. The window resets
+  on each swallowed pair; recording mechanics run as normal underneath
+  (a merged visit may span multiple visit files — acceptable; the row is the
+  unit of meaning, the files are the unit of storage).
+- **Window expires with no re-arrival** → the departure is real: notification
+  sends (up to `merge_window_seconds` late — accepted cost, stated here
+  deliberately) and the merged row is appended.
 
-Key decisions:
-- Where does busy mode live — state machine, buffer_monitor, or a new layer?
-- How is "busy" surfaced to the viewer? (Different clip label? Separate feed?)
+### Minimum significance
+
+Detection-duration = `visit_end − visit_start` — both are detection
+timestamps from the state machine, so this already excludes the
+`exit_timeout` tail. Visits below `min_significant_seconds` (default 30) are
+**recorded log-only**: no notification, event JSON row appended with
+`insignificant: true`. The row still exists — data is never thrown away,
+only de-surfaced.
+
+This supersedes `short_visit_threshold`, which is validated in
+`config.py:270` but consumed nowhere in the detection path — a dead key
+documented as if it worked. 025-B marks it deprecated in the template.
+
+### Activity-rate damping
+
+Above `damping_arrivals_threshold` arrivals (default 8) within
+`damping_window_hours` (default 1), the filter enters damped mode:
+individual arrival/departure notifications are suppressed and replaced by a
+periodic summary notification ("N visits in the last hour, median Xs").
+Recording and event rows are unaffected. Damped mode exits when the rate
+drops below threshold. Busy mode lives in the filter — not the state
+machine, not `buffer_monitor` — answering the scaffold's question 1.
+
+### Config surface
+
+```yaml
+significance_filter_enabled: true   # master switch; false = today's behavior
+merge_window_seconds: 300           # DEPARTED→ARRIVED within this = same visit
+min_significant_seconds: 30         # below this detection-duration: log-only
+damping_arrivals_threshold: 8       # arrivals within the window to enter damped mode
+damping_window_hours: 1             # rolling window for the arrival count
+```
+
+Backward compatibility: `significance_filter_enabled: false` (or `0` values)
+reproduces current behavior exactly; cams opt in per config, answering the
+scaffold's question 4. Per-cam tuning is the point — Fort Wayne nesting
+season aggressive, Harvard conservative.
 
 ---
 
-## Architecture questions
+## Acceptance criteria
 
-1. **Where does the merge window live?** Options:
-   - In `FalconStateMachine` — cleanest, but state machine currently knows nothing about time between events
-   - In `BufferMonitor._handle_event` — pragmatic, but adds logic to an already busy method
-   - In a new `EventSignificanceFilter` class between the state machine and the event handler
+- DEPARTED followed by ARRIVED within `merge_window_seconds`: one merged
+  visit row (correct span, `merged_segments` ≥ 2), no departure or arrival
+  notification for the swallowed pair, continuation arrival clip discarded.
+- DEPARTED with no re-arrival: notification and row released at window
+  expiry, content identical to today's except timing.
+- Visit under `min_significant_seconds`: row appended with
+  `insignificant: true`, no notification.
+- Arrival rate above threshold: individual notifications stop, summary
+  notifications start; rate drops → normal notifications resume.
+- Filter disabled: behavior byte-identical to current, verified by test.
+- State machine and recording mechanics untouched — existing tests unmodified
+  and green.
 
-2. **What is the SWAP event?** Currently the event types are ARRIVED, DEPARTED, ROOSTING. A SWAP (or NEST_SWAP) event might be cleaner than a merge — it names what happened, lets the viewer display it differently, and doesn't conflate "bird came and went" with "birds traded duty."
+## Verification
 
-3. **Config surface:** What does the config.yaml interface look like? Proposal:
-   ```yaml
-   event_merge_window_minutes: 10       # merge DEPARTED+ARRIVED within this window
-   min_detection_duration_seconds: 30   # below this, log-only (no clip, no notify)
-   busy_mode_threshold_per_hour: 8      # enter busy mode above this arrival rate
-   ```
+```bash
+black --check .
+isort --check .
+mypy src/
+pytest
+```
 
-4. **Backward compatibility:** Cams in normal operation (Harvard, NSW) should not be affected unless they opt in with non-zero values.
+`mypy src/` is currently clean — keep it clean. `pytest` runs repo-wide with
+coverage per `pytest.ini`. The filter ships with a dedicated test file
+(`tests/test_significance_filter.py`) driving synthetic event sequences
+through time; new logic must be well-tested. Historic repo-wide coverage is
+~46% and this ho does not claim a repo-wide gate.
+
+## Agent tasks
+
+| Task | Scope |
+|---|---|
+| [025-A](Agent-Tasks/025-A-significance-filter-module.md) | `EventSignificanceFilter` module + `tests/test_significance_filter.py` |
+| [025-B](Agent-Tasks/025-B-significance-filter-integration.md) | `buffer_monitor` wiring, `FalconVisit` flags, config keys + template, `short_visit_threshold` deprecation |
+
+Execution order: 025-A → 025-B. **After ho-12 (024 series) is deployed and
+observed** — this filter tunes against real residual churn, not recognition
+noise.
 
 ---
 
-## Files likely touched
+## Deferred to future hos
 
-- `src/kanyo/detection/falcon_state.py` — possibly; merge window might need state machine awareness
-- `src/kanyo/detection/buffer_monitor.py` — merge window logic if kept in event handler
-- `src/kanyo/detection/event_types.py` — new SWAP event type (possibly)
-- `src/kanyo/utils/config.py` — new config keys and defaults
-- `src/kanyo/utils/config_template.yaml` / `configs/config.template.yaml` — document new keys
-- Tests: new test file `tests/test_significance_filter.py`
-
----
-
-## Open questions for authoring session
-
-1. SWAP as a named event vs. silent merge — which model is cleaner for the viewer?
-2. Does the merge window need to know what the state machine's current visit looks like (duration, detection count) to decide whether to merge or split?
-3. Fort Wayne-specific: during active incubation, what interval between events actually indicates a meaningful behavioral change rather than a routine swap? (Biological question with engineering implications.)
-4. Does busy mode belong in this ho or a subsequent one?
+- VLM "what is happening here?" reasoning layered on top (future ho).
+- The Fort Wayne biological question — what inter-event interval indicates a
+  meaningful behavioral change during incubation — is a tuning question
+  against post-ho-12 data, not a design blocker; the config surface above is
+  where its answer lands.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ module = [
     "kanyo.utils.visit_recorder",
     "kanyo.utils.arrival_clip_recorder",
     "kanyo.detection.event_handler",
+    "kanyo.detection.significance_filter",
     "kanyo.detection.buffer_monitor",
     "kanyo.detection.buffer_clip_manager",
 ]

--- a/src/kanyo/detection/significance_filter.py
+++ b/src/kanyo/detection/significance_filter.py
@@ -1,0 +1,374 @@
+"""
+Event significance filter (ho-09 / 025-A).
+
+The judgment layer between state-machine events and their surface effects
+(notifications, event-store rows). The state machine stays pure — it reports
+what happened; this filter decides what it means. Recording mechanics run on
+raw events elsewhere; the filter governs only the surface.
+
+Three behaviors:
+
+- **Merge window** — a DEPARTED is held for ``merge_window_seconds``; an
+  ARRIVED inside the window is a continuation of the same visit (no new
+  notification, continuation arrival clip discarded, one merged row with a
+  ``merged_segments`` count). Window expiry releases the departure.
+- **Minimum significance** — visits with detection-duration below
+  ``min_significant_seconds`` are de-surfaced, never dropped: the row is
+  still recorded, flagged ``insignificant``, with no notification.
+- **Activity damping** — above ``damping_arrivals_threshold`` pass-through
+  arrivals per ``damping_window_hours``, individual notifications are
+  suppressed and ``tick`` emits one summary decision per window.
+
+Pure and deterministic: all time comes in as arguments — no wall-clock reads.
+The module emits :class:`FilterDecision` objects; it never sends
+notifications or writes files itself. Pipeline wiring is 025-B.
+"""
+
+from __future__ import annotations
+
+import statistics
+from collections import deque
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from kanyo.detection.event_types import FalconEvent
+from kanyo.detection.falcon_state import EventMetadata, StateEvent
+from kanyo.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class FilterDecision:
+    """One surface decision about a state-machine event.
+
+    ``event_type`` is ``None`` only for damping summary pseudo-decisions
+    (``is_summary=True``) — the event vocabulary does not grow (ho-09).
+    """
+
+    event_type: FalconEvent | None
+    event_time: datetime
+    metadata: EventMetadata
+    notify: bool  # send the public notification?
+    record: bool  # append the event-store row now?
+    merged_segments: int = 1  # >= 2 when this row spans merged visits
+    insignificant: bool = False  # below min_significant_seconds
+    discard_arrival_clip: bool = False  # continuation clip to delete (merge case)
+    is_summary: bool = False  # damping summary pseudo-decision
+
+
+class EventSignificanceFilter:
+    """Holds, merges, classifies, and releases state-machine events.
+
+    All behaviors are individually disabled by ``0`` values, and the whole
+    filter by ``enabled=False`` — pass-through decisions then reproduce
+    today's behavior exactly (ho-09 backward-compatibility contract).
+    """
+
+    def __init__(
+        self,
+        merge_window_seconds: float = 300,
+        min_significant_seconds: float = 30,
+        damping_arrivals_threshold: int = 8,
+        damping_window_hours: float = 1,
+        enabled: bool = True,
+    ):
+        self.merge_window_seconds = merge_window_seconds
+        self.min_significant_seconds = min_significant_seconds
+        self.damping_arrivals_threshold = damping_arrivals_threshold
+        self.damping_window_hours = damping_window_hours
+        self.enabled = enabled
+
+        # Held DEPARTED awaiting merge-window expiry: (event_time, metadata).
+        # The metadata is already merged (visit_start of the chain's first
+        # segment) at hold time.
+        self._held: tuple[datetime, EventMetadata] | None = None
+        # Open merge chain: first segment's visit_start and segment count.
+        # A chain opens when an ARRIVED swallows a held DEPARTED and closes
+        # when the eventual real departure is released.
+        self._chain_visit_start: datetime | None = None
+        self._chain_segments: int = 1
+
+        # Damping state: rolling deque of pass-through ARRIVED timestamps
+        # and of released visit (timestamp, detection-duration) pairs for
+        # the summary median.
+        self._arrivals: deque[datetime] = deque()
+        self._recent_durations: deque[tuple[datetime, float]] = deque()
+        self._damped = False
+        self._last_summary_time: datetime | None = None
+
+    # ── public API ────────────────────────────────────────────────────────
+
+    def process(self, event: StateEvent, now: datetime) -> list[FilterDecision]:
+        """Feed one state-machine event through the filter.
+
+        Args:
+            event: The (event_type, event_time, metadata) tuple.
+            now: The caller's driving timestamp (frame read time).
+
+        Returns:
+            Zero decisions (held), one, or several (a release plus the new
+            event).
+        """
+        event_type, event_time, metadata = event
+
+        if not self.enabled:
+            # Pass-through: today's behavior exactly, no holds.
+            return [FilterDecision(event_type, event_time, metadata, notify=True, record=True)]
+
+        if event_type == FalconEvent.DEPARTED:
+            return self._process_departed(event_time, metadata, now)
+        if event_type == FalconEvent.ARRIVED:
+            return self._process_arrived(event_time, metadata, now)
+
+        # ROOSTING (and anything else) passes through untouched — it has no
+        # event-store row today.
+        return [FilterDecision(event_type, event_time, metadata, notify=True, record=False)]
+
+    def tick(self, now: datetime) -> list[FilterDecision]:
+        """Advance time: release expired holds, emit due damping summaries.
+
+        Called once per poll by the integration.
+        """
+        if not self.enabled:
+            return []
+
+        decisions: list[FilterDecision] = []
+
+        if self._held is not None and self._window_expired(now):
+            decisions.append(self._release(now))
+
+        self._prune(now)
+        self._update_damped(now)
+
+        if self._damped and self._summary_due(now):
+            decisions.append(self._make_summary(now))
+
+        return decisions
+
+    def flush(self, now: datetime) -> list[FilterDecision]:
+        """Release any held departure immediately (shutdown path).
+
+        No row is ever lost on SIGTERM: the held DEPARTED is released
+        regardless of its merge window.
+        """
+        if self._held is not None:
+            return [self._release(now)]
+        return []
+
+    def state_info(self) -> dict[str, Any]:
+        """Diagnostic snapshot of filter state."""
+        held_time = self._held[0] if self._held is not None else None
+        return {
+            "enabled": self.enabled,
+            "held_departure": held_time.isoformat() if held_time else None,
+            "chain_segments": self._chain_segments,
+            "chain_visit_start": (
+                self._chain_visit_start.isoformat() if self._chain_visit_start else None
+            ),
+            "damped": self._damped,
+            "arrivals_in_window": len(self._arrivals),
+            "merge_window_seconds": self.merge_window_seconds,
+            "min_significant_seconds": self.min_significant_seconds,
+            "damping_arrivals_threshold": self.damping_arrivals_threshold,
+            "damping_window_hours": self.damping_window_hours,
+        }
+
+    # ── event handling ────────────────────────────────────────────────────
+
+    def _process_departed(
+        self, event_time: datetime, metadata: EventMetadata, now: datetime
+    ) -> list[FilterDecision]:
+        decisions: list[FilterDecision] = []
+
+        if self._held is not None:
+            # Defensive: the state machine cannot fire DEPARTED twice without
+            # an intervening ARRIVED. Release the stale hold rather than
+            # silently overwrite it.
+            logger.warning("DEPARTED while another is held — releasing the stale hold")
+            decisions.append(self._release(now))
+
+        merged = dict(metadata)
+        if self._chain_visit_start is not None:
+            # Continuation chain in progress: the merged row spans the first
+            # segment's visit_start to this departure's visit_end.
+            merged["visit_start"] = self._chain_visit_start
+            visit_end = merged.get("visit_end")
+            if isinstance(visit_end, datetime):
+                duration = (visit_end - self._chain_visit_start).total_seconds()
+                merged["visit_duration_seconds"] = duration
+                if "total_visit_duration" in merged:
+                    merged["total_visit_duration"] = duration
+
+        self._held = (event_time, merged)
+
+        if self.merge_window_seconds <= 0 or self._window_expired(now):
+            # Merging disabled, or the window (measured from event_time,
+            # which already trails ``now`` by exit_timeout) has no time
+            # left — release immediately.
+            decisions.append(self._release(now))
+
+        return decisions
+
+    def _process_arrived(
+        self, event_time: datetime, metadata: EventMetadata, now: datetime
+    ) -> list[FilterDecision]:
+        decisions: list[FilterDecision] = []
+
+        if self._held is not None:
+            held_time, held_metadata = self._held
+            in_window = (
+                self.merge_window_seconds > 0
+                and (now - held_time).total_seconds() <= self.merge_window_seconds
+            )
+            if in_window:
+                # Continuation of the same visit: swallow both events. The
+                # held row stays pending; the chain remembers the first
+                # segment's visit_start; the continuation's arrival clip is
+                # marked for discard on a zero-surface decision.
+                chain_start = held_metadata.get("visit_start")
+                if isinstance(chain_start, datetime):
+                    self._chain_visit_start = chain_start
+                self._chain_segments += 1
+                self._held = None
+                logger.event(
+                    f"🔗 Re-arrival within merge window — visit continues "
+                    f"(segment {self._chain_segments})"
+                )
+                decisions.append(
+                    FilterDecision(
+                        FalconEvent.ARRIVED,
+                        event_time,
+                        metadata,
+                        notify=False,
+                        record=False,
+                        merged_segments=self._chain_segments,
+                        discard_arrival_clip=True,
+                    )
+                )
+                return decisions
+
+            # Window expired: the held departure was real. Release it, then
+            # treat this arrival as a fresh pass-through.
+            decisions.append(self._release(now))
+
+        self._note_arrival(now)
+        decisions.append(
+            FilterDecision(
+                FalconEvent.ARRIVED,
+                event_time,
+                metadata,
+                notify=not self._damped,
+                record=False,
+            )
+        )
+        return decisions
+
+    # ── release / significance ────────────────────────────────────────────
+
+    def _release(self, now: datetime) -> FilterDecision:
+        """Release the held DEPARTED as a surfaced (or de-surfaced) row."""
+        assert self._held is not None, "release called with nothing held"
+        event_time, metadata = self._held
+        segments = self._chain_segments
+
+        duration = self._detection_duration(metadata)
+        insignificant = self.min_significant_seconds > 0 and duration < self.min_significant_seconds
+        notify = not insignificant and not self._damped
+
+        self._recent_durations.append((now, duration))
+        self._held = None
+        self._chain_visit_start = None
+        self._chain_segments = 1
+
+        if insignificant:
+            logger.event(
+                f"🔎 Visit below significance threshold ({duration:.0f}s < "
+                f"{self.min_significant_seconds:.0f}s) — recorded log-only"
+            )
+
+        return FilterDecision(
+            FalconEvent.DEPARTED,
+            event_time,
+            metadata,
+            notify=notify,
+            record=True,
+            merged_segments=segments,
+            insignificant=insignificant,
+        )
+
+    @staticmethod
+    def _detection_duration(metadata: EventMetadata) -> float:
+        """Detection-duration from (merged) metadata.
+
+        ``visit_end − visit_start`` — both detection timestamps from the
+        state machine, so the exit_timeout tail is already excluded.
+        """
+        visit_start = metadata.get("visit_start")
+        visit_end = metadata.get("visit_end")
+        if isinstance(visit_start, datetime) and isinstance(visit_end, datetime):
+            return (visit_end - visit_start).total_seconds()
+        return float(metadata.get("visit_duration_seconds") or 0.0)
+
+    def _window_expired(self, now: datetime) -> bool:
+        assert self._held is not None
+        held_time = self._held[0]
+        return (now - held_time).total_seconds() > self.merge_window_seconds
+
+    # ── damping ───────────────────────────────────────────────────────────
+
+    def _note_arrival(self, now: datetime) -> None:
+        self._arrivals.append(now)
+        self._prune(now)
+        self._update_damped(now)
+
+    def _prune(self, now: datetime) -> None:
+        window_seconds = self.damping_window_hours * 3600
+        while self._arrivals and (now - self._arrivals[0]).total_seconds() > window_seconds:
+            self._arrivals.popleft()
+        while (
+            self._recent_durations
+            and (now - self._recent_durations[0][0]).total_seconds() > window_seconds
+        ):
+            self._recent_durations.popleft()
+
+    def _update_damped(self, now: datetime) -> None:
+        active = (
+            self.damping_arrivals_threshold > 0
+            and len(self._arrivals) > self.damping_arrivals_threshold
+        )
+        if active and not self._damped:
+            self._damped = True
+            self._last_summary_time = None  # first tick emits a summary
+            logger.event(
+                f"🔕 Activity damping ON: {len(self._arrivals)} arrivals in the last "
+                f"{self.damping_window_hours}h (threshold {self.damping_arrivals_threshold}) "
+                f"— switching to summary notifications"
+            )
+        elif not active and self._damped:
+            self._damped = False
+            logger.event("🔔 Activity damping OFF — normal notifications resume")
+
+    def _summary_due(self, now: datetime) -> bool:
+        if self._last_summary_time is None:
+            return True
+        window_seconds = self.damping_window_hours * 3600
+        return (now - self._last_summary_time).total_seconds() >= window_seconds
+
+    def _make_summary(self, now: datetime) -> FilterDecision:
+        durations = [duration for _, duration in self._recent_durations]
+        median_duration = statistics.median(durations) if durations else 0.0
+        self._last_summary_time = now
+        return FilterDecision(
+            None,
+            now,
+            {
+                "count": len(self._arrivals),
+                "median_duration_seconds": median_duration,
+                "window_hours": self.damping_window_hours,
+            },
+            notify=True,
+            record=False,
+            is_summary=True,
+        )

--- a/tests/test_significance_filter.py
+++ b/tests/test_significance_filter.py
@@ -1,0 +1,444 @@
+"""Tests for the EventSignificanceFilter (ho-09 / 025-A).
+
+Scripted event sequences with explicit timestamps drive the filter through
+time deterministically — no wall-clock reads anywhere in the module.
+"""
+
+from datetime import datetime, timedelta
+
+from kanyo.detection.event_types import FalconEvent
+from kanyo.detection.significance_filter import EventSignificanceFilter, FilterDecision
+
+T0 = datetime(2026, 7, 16, 12, 0, 0)
+
+
+def ts(seconds: float) -> datetime:
+    """Timestamp ``seconds`` after T0."""
+    return T0 + timedelta(seconds=seconds)
+
+
+def departed_metadata(start: datetime, end: datetime) -> dict:
+    """DEPARTED metadata as the state machine builds it."""
+    duration = (end - start).total_seconds()
+    return {
+        "visit_start": start,
+        "visit_end": end,
+        "visit_duration_seconds": duration,
+        "total_visit_duration": duration,
+    }
+
+
+def depart(
+    filt: EventSignificanceFilter,
+    start: datetime,
+    end: datetime,
+    now: datetime,
+) -> list[FilterDecision]:
+    """Feed a DEPARTED for the visit [start, end] through the filter."""
+    return filt.process((FalconEvent.DEPARTED, end, departed_metadata(start, end)), now)
+
+
+def arrive(
+    filt: EventSignificanceFilter, when: datetime, now: datetime | None = None
+) -> list[FilterDecision]:
+    """Feed an ARRIVED at ``when`` through the filter."""
+    return filt.process((FalconEvent.ARRIVED, when, {"visit_start": when}), now or when)
+
+
+class TestMergeWindow:
+    def test_departed_then_rearrival_merges_into_one_row(self):
+        """DEPARTED then ARRIVED at +120s: both swallowed; the eventual real
+        departure releases ONE row spanning first arrival to last visit_end,
+        merged_segments == 2, one notification."""
+        filt = EventSignificanceFilter(merge_window_seconds=300)
+
+        # First visit: T0 → T0+600. DEPARTED processed at its event time.
+        decisions = depart(filt, ts(0), ts(600), now=ts(600))
+        assert decisions == []  # held
+
+        # Re-arrival 120s later: swallowed.
+        decisions = arrive(filt, ts(720))
+        assert len(decisions) == 1
+        swallowed = decisions[0]
+        assert swallowed.notify is False
+        assert swallowed.record is False
+        assert swallowed.discard_arrival_clip is True
+        assert swallowed.merged_segments == 2
+
+        # Second segment departs at +900s; held with merged metadata.
+        decisions = depart(filt, ts(720), ts(900), now=ts(900))
+        assert decisions == []
+
+        # Window expires: one merged release.
+        decisions = filt.tick(ts(900 + 301))
+        assert len(decisions) == 1
+        released = decisions[0]
+        assert released.event_type == FalconEvent.DEPARTED
+        assert released.notify is True
+        assert released.record is True
+        assert released.merged_segments == 2
+        assert released.metadata["visit_start"] == ts(0)
+        assert released.metadata["visit_end"] == ts(900)
+        assert released.metadata["visit_duration_seconds"] == 900.0
+        assert released.metadata["total_visit_duration"] == 900.0
+
+    def test_departed_with_no_rearrival_released_at_expiry(self):
+        """A lone DEPARTED is released via tick at window expiry with its
+        metadata unchanged."""
+        filt = EventSignificanceFilter(merge_window_seconds=300)
+        metadata = departed_metadata(ts(0), ts(600))
+
+        assert filt.process((FalconEvent.DEPARTED, ts(600), metadata), ts(600)) == []
+        assert filt.tick(ts(600 + 300)) == []  # boundary: not yet expired
+
+        decisions = filt.tick(ts(600 + 301))
+        assert len(decisions) == 1
+        released = decisions[0]
+        assert released.event_type == FalconEvent.DEPARTED
+        assert released.event_time == ts(600)
+        assert released.notify is True
+        assert released.record is True
+        assert released.merged_segments == 1
+        assert released.insignificant is False
+        assert released.metadata == metadata
+
+    def test_three_segment_chain(self):
+        """Two swallowed pairs produce merged_segments == 3."""
+        filt = EventSignificanceFilter(merge_window_seconds=300)
+
+        assert depart(filt, ts(0), ts(600), now=ts(600)) == []
+        assert arrive(filt, ts(700))[0].merged_segments == 2
+        assert depart(filt, ts(700), ts(1300), now=ts(1300)) == []
+        assert arrive(filt, ts(1400))[0].merged_segments == 3
+        assert depart(filt, ts(1400), ts(2000), now=ts(2000)) == []
+
+        decisions = filt.tick(ts(2000 + 301))
+        assert len(decisions) == 1
+        released = decisions[0]
+        assert released.merged_segments == 3
+        assert released.metadata["visit_start"] == ts(0)
+        assert released.metadata["visit_end"] == ts(2000)
+
+    def test_arrival_after_window_releases_hold_and_passes_through(self):
+        """An ARRIVED past the window releases the held DEPARTED and passes
+        through itself — two decisions from one event."""
+        filt = EventSignificanceFilter(merge_window_seconds=300)
+
+        assert depart(filt, ts(0), ts(600), now=ts(600)) == []
+        decisions = arrive(filt, ts(600 + 400))
+
+        assert len(decisions) == 2
+        released, passed = decisions
+        assert released.event_type == FalconEvent.DEPARTED
+        assert released.notify is True
+        assert released.record is True
+        assert released.merged_segments == 1
+        assert passed.event_type == FalconEvent.ARRIVED
+        assert passed.notify is True
+        assert passed.discard_arrival_clip is False
+
+    def test_merge_window_zero_disables_merging(self):
+        """merge_window_seconds=0: DEPARTED released immediately in process."""
+        filt = EventSignificanceFilter(merge_window_seconds=0)
+
+        decisions = depart(filt, ts(0), ts(600), now=ts(600))
+        assert len(decisions) == 1
+        assert decisions[0].event_type == FalconEvent.DEPARTED
+        assert decisions[0].notify is True
+        assert decisions[0].record is True
+
+    def test_double_departed_releases_stale_hold_defensively(self):
+        """The state machine cannot fire DEPARTED twice without an ARRIVED,
+        but a stale hold is released rather than silently overwritten."""
+        filt = EventSignificanceFilter(merge_window_seconds=300)
+
+        assert depart(filt, ts(0), ts(600), now=ts(600)) == []
+        decisions = depart(filt, ts(700), ts(900), now=ts(900))
+
+        assert len(decisions) == 1  # the stale hold, released
+        assert decisions[0].event_type == FalconEvent.DEPARTED
+        assert decisions[0].metadata["visit_end"] == ts(600)
+        # The new DEPARTED is now the held one.
+        assert filt.state_info()["held_departure"] == ts(900).isoformat()
+
+    def test_duration_falls_back_to_metadata_seconds(self):
+        """Without datetime span fields, visit_duration_seconds decides
+        significance."""
+        filt = EventSignificanceFilter(merge_window_seconds=0, min_significant_seconds=30)
+
+        decisions = filt.process(
+            (FalconEvent.DEPARTED, ts(600), {"visit_duration_seconds": 20.0}), ts(600)
+        )
+        assert decisions[0].insignificant is True
+
+    def test_hold_already_expired_at_process_time_released_immediately(self):
+        """DEPARTED whose event_time already trails ``now`` past the window
+        (long exit_timeout) is released in the same process call."""
+        filt = EventSignificanceFilter(merge_window_seconds=60)
+
+        # event_time (visit_end) is 90s before now — beyond the 60s window.
+        decisions = depart(filt, ts(0), ts(600), now=ts(690))
+        assert len(decisions) == 1
+        assert decisions[0].event_type == FalconEvent.DEPARTED
+
+
+class TestMinimumSignificance:
+    def test_short_visit_recorded_log_only(self):
+        """A 20-second visit is released insignificant: no notification,
+        row still recorded."""
+        filt = EventSignificanceFilter(min_significant_seconds=30)
+
+        assert depart(filt, ts(0), ts(20), now=ts(20)) == []
+        decisions = filt.tick(ts(20 + 301))
+
+        assert len(decisions) == 1
+        released = decisions[0]
+        assert released.insignificant is True
+        assert released.notify is False
+        assert released.record is True
+
+    def test_merged_visit_still_under_threshold_is_insignificant(self):
+        """Merge + insignificance interaction: a merged visit whose total
+        detection-duration is still under threshold stays insignificant."""
+        filt = EventSignificanceFilter(merge_window_seconds=300, min_significant_seconds=30)
+
+        # 10s visit, re-arrival, 5s second segment: merged span T0 → T0+25.
+        assert depart(filt, ts(0), ts(10), now=ts(10)) == []
+        assert arrive(filt, ts(20))[0].discard_arrival_clip is True
+        assert depart(filt, ts(20), ts(25), now=ts(25)) == []
+
+        decisions = filt.tick(ts(25 + 301))
+        assert len(decisions) == 1
+        released = decisions[0]
+        assert released.merged_segments == 2
+        assert released.insignificant is True
+        assert released.notify is False
+        assert released.record is True
+        assert released.metadata["visit_duration_seconds"] == 25.0
+
+    def test_merged_visit_over_threshold_is_significant(self):
+        """The merged span, not the last segment, decides significance."""
+        filt = EventSignificanceFilter(merge_window_seconds=300, min_significant_seconds=30)
+
+        # 20s segment + 10s segment, but the merged span is 50s.
+        assert depart(filt, ts(0), ts(20), now=ts(20)) == []
+        arrive(filt, ts(40))
+        assert depart(filt, ts(40), ts(50), now=ts(50)) == []
+
+        released = filt.tick(ts(50 + 301))[0]
+        assert released.insignificant is False
+        assert released.notify is True
+
+    def test_threshold_zero_disables_significance_gate(self):
+        filt = EventSignificanceFilter(merge_window_seconds=0, min_significant_seconds=0)
+
+        decisions = depart(filt, ts(0), ts(5), now=ts(5))
+        assert decisions[0].insignificant is False
+        assert decisions[0].notify is True
+
+
+class TestActivityDamping:
+    def _arrive_n(self, filt: EventSignificanceFilter, count: int, spacing: float = 60):
+        """Drive ``count`` pass-through arrivals ``spacing`` seconds apart.
+        Returns the list of per-arrival decisions."""
+        decisions = []
+        for i in range(count):
+            when = ts(i * spacing)
+            result = arrive(filt, when)
+            assert len(result) == 1
+            decisions.append(result[0])
+        return decisions
+
+    def test_ninth_arrival_enters_damped_mode(self):
+        """Nine arrivals in an hour with threshold 8: the ninth is damped;
+        tick yields a summary; a rate drop restores notifications."""
+        filt = EventSignificanceFilter(damping_arrivals_threshold=8, damping_window_hours=1)
+
+        decisions = self._arrive_n(filt, 9, spacing=60)
+        assert all(d.notify for d in decisions[:8])
+        assert decisions[8].notify is False
+
+        # Tick emits exactly one summary per window.
+        summaries = filt.tick(ts(9 * 60))
+        assert len(summaries) == 1
+        summary = summaries[0]
+        assert summary.is_summary is True
+        assert summary.event_type is None
+        assert summary.notify is True
+        assert summary.record is False
+        assert summary.metadata["count"] == 9
+        assert filt.tick(ts(9 * 60 + 30)) == []  # no second summary yet
+
+        # Two hours later the window is empty: notifications resume.
+        late = arrive(filt, ts(2 * 3600))
+        assert late[0].notify is True
+
+    def test_tick_alone_exits_damped_mode(self):
+        """Damped mode exits via tick when arrivals age out of the window."""
+        filt = EventSignificanceFilter(damping_arrivals_threshold=2, damping_window_hours=1)
+        self._arrive_n(filt, 3, spacing=10)
+        assert filt.state_info()["damped"] is True
+
+        filt.tick(ts(2 * 3600))
+        assert filt.state_info()["damped"] is False
+
+    def test_released_durations_age_out_of_the_summary_window(self):
+        """Old released visits are pruned from the summary median data."""
+        filt = EventSignificanceFilter(
+            merge_window_seconds=0,
+            min_significant_seconds=0,
+            damping_arrivals_threshold=2,
+            damping_window_hours=1,
+        )
+        # One visit released early, well before the damped stretch.
+        arrive(filt, ts(0))
+        depart(filt, ts(0), ts(100), now=ts(100))
+
+        # Three hours later, a burst enters damped mode with fresh visits.
+        base = 3 * 3600
+        for i in range(3):
+            start = ts(base + i * 300)
+            arrive(filt, start)
+            depart(filt, start, start + timedelta(seconds=40), now=ts(base + i * 300 + 50))
+
+        summary = filt.tick(ts(base + 1000))[0]
+        assert summary.metadata["count"] == 3  # the early arrival aged out
+        assert summary.metadata["median_duration_seconds"] == 40.0
+
+    def test_summary_median_from_released_durations(self):
+        """The summary median comes from visits released within the window."""
+        filt = EventSignificanceFilter(
+            merge_window_seconds=0,
+            min_significant_seconds=0,
+            damping_arrivals_threshold=2,
+            damping_window_hours=1,
+        )
+
+        # Three arrivals (damped after the third) with released visits of
+        # 10s, 20s, and 40s → median 20.
+        for i, duration in enumerate((10, 20, 40)):
+            start = ts(i * 300)
+            arrive(filt, start)
+            depart(filt, start, start + timedelta(seconds=duration), now=ts(i * 300 + 60))
+
+        summaries = filt.tick(ts(1000))
+        assert len(summaries) == 1
+        assert summaries[0].metadata["median_duration_seconds"] == 20.0
+
+    def test_damped_departure_release_suppresses_notification(self):
+        """While damped, a released departure records its row but does not
+        notify individually."""
+        filt = EventSignificanceFilter(
+            merge_window_seconds=60,
+            min_significant_seconds=0,
+            damping_arrivals_threshold=2,
+            damping_window_hours=1,
+        )
+        self._arrive_n(filt, 3, spacing=10)  # damped
+
+        assert depart(filt, ts(30), ts(400), now=ts(400)) == []
+        released = filt.tick(ts(400 + 61))[0]
+        assert released.event_type == FalconEvent.DEPARTED
+        assert released.notify is False
+        assert released.record is True
+        assert released.insignificant is False
+
+    def test_threshold_zero_disables_damping(self):
+        filt = EventSignificanceFilter(damping_arrivals_threshold=0)
+        decisions = self._arrive_n(filt, 20, spacing=10)
+        assert all(d.notify for d in decisions)
+        assert filt.tick(ts(300)) == []
+
+
+class TestDisabled:
+    def test_every_event_passes_through_immediately(self):
+        """enabled=False: pass-through with notify=True, record=True, no
+        holds — today's behavior."""
+        filt = EventSignificanceFilter(enabled=False)
+
+        for event_type, event_time, metadata in (
+            (FalconEvent.ARRIVED, ts(0), {"visit_start": ts(0)}),
+            (FalconEvent.ROOSTING, ts(1800), {"visit_duration_seconds": 1800}),
+            (FalconEvent.DEPARTED, ts(20), departed_metadata(ts(0), ts(20))),
+        ):
+            decisions = filt.process((event_type, event_time, metadata), event_time)
+            assert len(decisions) == 1
+            decision = decisions[0]
+            assert decision.event_type == event_type
+            assert decision.event_time == event_time
+            assert decision.metadata == metadata
+            assert decision.notify is True
+            assert decision.record is True
+            assert decision.merged_segments == 1
+            assert decision.insignificant is False
+            assert decision.discard_arrival_clip is False
+
+        assert filt.state_info()["held_departure"] is None
+        assert filt.tick(ts(10_000)) == []
+
+    def test_disabled_short_visit_not_flagged(self):
+        """A 5-second visit passes through unflagged when disabled."""
+        filt = EventSignificanceFilter(enabled=False, min_significant_seconds=30)
+        decisions = depart(filt, ts(0), ts(5), now=ts(5))
+        assert decisions[0].insignificant is False
+        assert decisions[0].notify is True
+
+
+class TestRoostingPassThrough:
+    def test_roosting_untouched(self):
+        """ROOSTING passes through with notify=True, record=False — it has
+        no event-store row today."""
+        filt = EventSignificanceFilter()
+        decisions = filt.process(
+            (FalconEvent.ROOSTING, ts(1800), {"visit_duration_seconds": 1800}), ts(1800)
+        )
+        assert len(decisions) == 1
+        assert decisions[0].notify is True
+        assert decisions[0].record is False
+
+    def test_roosting_passes_through_while_departure_held(self):
+        """A ROOSTING inside a continuation chain does not disturb the hold."""
+        filt = EventSignificanceFilter(merge_window_seconds=300)
+        assert depart(filt, ts(0), ts(600), now=ts(600)) == []
+        arrive(filt, ts(700))  # swallowed — chain open, visit continues
+
+        decisions = filt.process((FalconEvent.ROOSTING, ts(2500), {}), ts(2500))
+        assert len(decisions) == 1
+        assert decisions[0].event_type == FalconEvent.ROOSTING
+
+
+class TestFlush:
+    def test_flush_releases_held_departure_immediately(self):
+        """Shutdown flush releases the held row regardless of the window."""
+        filt = EventSignificanceFilter(merge_window_seconds=300)
+        assert depart(filt, ts(0), ts(600), now=ts(600)) == []
+
+        decisions = filt.flush(ts(610))
+        assert len(decisions) == 1
+        assert decisions[0].event_type == FalconEvent.DEPARTED
+        assert decisions[0].record is True
+
+        assert filt.flush(ts(620)) == []  # nothing left to flush
+
+    def test_flush_with_nothing_held(self):
+        assert EventSignificanceFilter().flush(ts(0)) == []
+
+
+class TestStateInfo:
+    def test_state_info_reflects_hold_and_chain(self):
+        filt = EventSignificanceFilter(merge_window_seconds=300)
+        info = filt.state_info()
+        assert info["enabled"] is True
+        assert info["held_departure"] is None
+        assert info["chain_segments"] == 1
+        assert info["damped"] is False
+
+        depart(filt, ts(0), ts(600), now=ts(600))
+        info = filt.state_info()
+        assert info["held_departure"] == ts(600).isoformat()
+
+        arrive(filt, ts(700))
+        info = filt.state_info()
+        assert info["held_departure"] is None
+        assert info["chain_segments"] == 2
+        assert info["chain_visit_start"] == ts(0).isoformat()


### PR DESCRIPTION
Implements the pure significance-filter module from ho-09 (agent task 025-A).

## What

- New `src/kanyo/detection/significance_filter.py`: `EventSignificanceFilter` + `FilterDecision` — the judgment layer between state-machine events and their surface effects (notifications, event-store rows). Recording mechanics are untouched; pipeline wiring is 025-B.
- **Merge window**: DEPARTED held for `merge_window_seconds`; a re-ARRIVED inside the window is a continuation — zero-surface decision with `discard_arrival_clip`, merged row spans first `visit_start` to last `visit_end` with `merged_segments >= 2`.
- **Minimum significance**: released visits under `min_significant_seconds` are `insignificant` — recorded, never notified, never dropped.
- **Activity damping**: above `damping_arrivals_threshold` pass-through arrivals per `damping_window_hours`, per-event notifications stop and `tick` emits one summary pseudo-decision per window (count + median duration).
- `enabled=False` and `0` values reproduce current behavior exactly (pass-through, no holds).
- `flush(now)` releases a held departure immediately (consumed by 025-B's SIGTERM path).

## Notes

- `FilterDecision.event_type` is `FalconEvent | None` — `None` only for damping summary pseudo-decisions (`is_summary=True`); the event vocabulary does not grow.
- Module added to the existing pyproject mypy override list for the dynamically-added `logger.event` (same pattern as buffer_monitor et al.).
- Also commits the authored ho-09 document replacing the scaffold.

## Verification

- `mypy src/` clean; touched files black/isort clean.
- `tests/test_significance_filter.py`: 25 deterministic time-driven tests, 100% module coverage.
- Full suite: 438 passed; only the 4 known pre-existing failures (test_detection blank-frame + 3 log_service TestShowContext).