### PR TITLE
025-B: Route event surface through significance filter (merge, significance, damping)

### DIFF
--- a/.keisaku.json
+++ b/.keisaku.json
@@ -59,6 +59,8 @@
           "note": "Six weeks, 114 tests, deployed at Harvard — the methodology's first existence proof."
         }
       ],
+      "availability": "shipped",
+      "usage": "others",
       "state": {
         "stage": "production",
         "last": "The bulk of the `021` sprint: a sequence of agent-task-driven fixes across admin timezone handling (021-G), arrival confirmation recording actual last detection time (021-J), buffer monitor startup / frame interval wiring (021-D), .mp4.tmp finalization in roosting-stop mode (021-E), stream data root unification (021-C), HTML/URL escaping in admin API handlers (021-H), admin restart/stop/start TypeError on thumbnail (021-B), EventMetadata/StateEvent type aliases bringing mypy to clean (021-K), pytest import without manual PYTHONPATH (021-A), CI build-cpu tag template fix (5557794), and output filename microsecond collision fix (021-I, commit a014025 — most recent merged). The ho-09 significance-filter doc was scaffolded (1e69053) but the ho is not yet authored or executed.",

--- a/configs/config.template.yaml
+++ b/configs/config.template.yaml
@@ -174,6 +174,53 @@ presence_absence_failsafe_seconds: 3600
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Significance Filter
+# ─────────────────────────────────────────────────────────────────────────────
+# The presence layer removes manufactured churn (recognition gaps on roosting
+# birds); the significance filter handles the REAL residual churn — genuine
+# short visits and rapid swaps during active nesting. It sits between the
+# state machine and the public surface: recording and clips always run on the
+# raw events, but notifications and the event timeline flow through the
+# filter's judgment. Data is never thrown away, only de-surfaced.
+#
+# significance_filter_enabled — Master switch. false restores today's
+#   behavior exactly: every arrival/departure notifies immediately and every
+#   visit gets its own timeline row.
+#
+# merge_window_seconds — A departure followed by a re-arrival within this
+#   many seconds is a CONTINUATION of the same visit (an incubation swap, a
+#   bird hopping off-ledge and back): no departure/arrival notifications for
+#   the pair, the redundant arrival clip is discarded, and the timeline gets
+#   ONE merged row spanning the whole stay (with a merged_segments count).
+#   NOTE — by design, the departure notification can arrive up to this many
+#   seconds late: the filter has to wait out the window before it knows the
+#   departure was real. 0 disables merging.
+#
+# min_significant_seconds — Visits with a detection-duration below this are
+#   recorded log-only: the row is written (flagged "insignificant") but no
+#   notification is sent. Replaces the deprecated short_visit_threshold —
+#   and unlike it, the visit is still kept, just not surfaced. 0 disables.
+#
+# damping_arrivals_threshold / damping_window_hours — Above this many
+#   arrivals within the rolling window, individual notifications pause and a
+#   periodic summary takes their place ("N visits in the last hour, median
+#   Xs"). Recording and timeline rows are unaffected. Normal notifications
+#   resume automatically when the rate drops. threshold 0 disables damping.
+#
+# Tuning guidance: during active nesting (Fort Wayne-style swap storms) be
+# aggressive — merge_window_seconds 300–600, min_significant_seconds 60,
+# damping threshold 6–8. On a quiet cliff camera (Harvard-style) be
+# conservative — merge_window_seconds 120, min_significant_seconds 15–30,
+# damping threshold 10+ — so nothing interesting is de-surfaced.
+
+significance_filter_enabled: true
+merge_window_seconds: 300
+min_significant_seconds: 30
+damping_arrivals_threshold: 8
+damping_window_hours: 1
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Roosting Mode
 # ─────────────────────────────────────────────────────────────────────────────
 # Controls what happens to recording and detection once the bird enters
@@ -291,16 +338,17 @@ record_arrival_on_startup: false
 # clip_departure_after  — Seconds after the last detected frame. Default:
 #   30 + 15 = 45 second departure clip, ending with ~15s of empty nest.
 #
-# short_visit_threshold — Visits shorter than this many seconds are not saved
-#   to the event store. Prevents cluttering the timeline with flyby detections
-#   that passed confirmation but never settled. Minimum: 60.
+# short_visit_threshold — DEPRECATED (ho-09). This key was documented as
+#   dropping short visits from the event store but is consumed nowhere in the
+#   detection path. Use min_significant_seconds (Significance Filter section)
+#   instead — it de-surfaces short visits (no notification) while still
+#   recording them. Setting this key only logs a deprecation warning.
 
 clips_dir: "clips"
 clip_arrival_before: 15
 clip_arrival_after: 30
 clip_departure_before: 30
 clip_departure_after: 15
-short_visit_threshold: 600
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -382,13 +430,13 @@ log_file: "logs/kanyo.log"
 # Default settings are optimised for a hobby monitoring setup:
 #   - roosting_recording_mode: continuous  (simple; change to stop to save disk)
 #   - detection_confidence: 0.3            (generous; catches most visits)
-#   - short_visit_threshold: 600           (skips brief flybys)
+#   - min_significant_seconds: 30          (brief flybys recorded but not notified)
 #   - model_path: yolov8n.pt               (fast nano model)
 #
 # For research archiving, consider:
 #   - roosting_recording_mode: continuous  (preserve complete visit footage)
 #   - detection_confidence: 0.2–0.25       (maximum recall; review false positives manually)
-#   - short_visit_threshold: 60            (capture even brief landings)
+#   - min_significant_seconds: 0           (surface even brief landings)
 #   - model_path: yolov8s.pt               (small model; better accuracy, more CPU)
 #   - No clip retention limits             (keep all footage indefinitely)
 #

--- a/src/kanyo/detection/buffer_monitor.py
+++ b/src/kanyo/detection/buffer_monitor.py
@@ -23,12 +23,16 @@ from kanyo.detection.event_types import FalconEvent  # noqa: E402
 from kanyo.detection.events import EventStore, FalconVisit  # noqa: E402
 from kanyo.detection.falcon_state import FalconStateMachine  # noqa: E402
 from kanyo.detection.presence import PresenceTracker  # noqa: E402
+from kanyo.detection.significance_filter import (  # noqa: E402
+    EventSignificanceFilter,
+    FilterDecision,
+)
 from kanyo.utils.arrival_clip_recorder import ArrivalClipRecorder  # noqa: E402
 from kanyo.utils.config import get_now_tz, load_config  # noqa: E402
 from kanyo.utils.frame_buffer import FrameBuffer  # noqa: E402
 from kanyo.utils.logger import get_logger, setup_logging_from_config  # noqa: E402
 from kanyo.utils.notifications import NotificationManager  # noqa: E402
-from kanyo.utils.output import get_output_path  # noqa: E402
+from kanyo.utils.output import format_duration, get_output_path  # noqa: E402
 from kanyo.utils.visit_recorder import VisitRecorder  # noqa: E402
 
 logger = get_logger(__name__)
@@ -101,6 +105,15 @@ class BufferMonitor:
         presence_motion_min_area_frac: float = 0.02,
         presence_global_change_frac: float = 0.5,
         presence_absence_failsafe_seconds: float = 3600.0,
+        # Significance filter settings (ho-09 / 025-B). The constructor
+        # default is False so direct construction (tests, embedders) keeps
+        # today's surface behavior; production configs carry the DEFAULTS
+        # (enabled) and main() wires them through.
+        significance_filter_enabled: bool = False,
+        merge_window_seconds: float = 300,
+        min_significant_seconds: float = 30,
+        damping_arrivals_threshold: int = 8,
+        damping_window_hours: float = 1,
         # Notification settings
         notify_on_startup: bool = True,
         record_arrival_on_startup: bool = False,
@@ -225,6 +238,32 @@ class BufferMonitor:
             }
         )
 
+        # Significance filter (ho-09 / 025-B): the judgment layer between
+        # state-machine events and their surface (notifications, event-store
+        # rows, clip retention). Recording mechanics keep running on raw
+        # events; only the surface flows through filter decisions. Disabled,
+        # its pass-through decisions reproduce today's behavior exactly.
+        self.significance_filter = EventSignificanceFilter(
+            merge_window_seconds=merge_window_seconds,
+            min_significant_seconds=min_significant_seconds,
+            damping_arrivals_threshold=damping_arrivals_threshold,
+            damping_window_hours=damping_window_hours,
+            enabled=significance_filter_enabled,
+        )
+        if significance_filter_enabled:
+            logger.info(
+                "🔎 Significance filter ENABLED (ho-09): departures may surface up to "
+                f"{merge_window_seconds:.0f}s late by design (merge window)"
+            )
+        # The frame time driving filter decisions (ho-11 time authority):
+        # set per processed frame; direct _handle_event calls fall back to
+        # the event's own timestamp.
+        self._frame_now: datetime | None = None
+        # The visit row awaiting a released departure decision. Continuation
+        # segments merge into it: the row is the unit of meaning, the visit
+        # files remain the unit of storage.
+        self._pending_visit_row: FalconVisit | None = None
+
         # State tracking
         self.current_visit: FalconVisit | None = None
         self.last_detection_time: datetime | None = None
@@ -317,6 +356,8 @@ class BufferMonitor:
         """
         try:
             now = timestamp
+            # Frame time drives significance-filter decisions too (025-B)
+            self._frame_now = now
 
             # Always add frame to buffer (read time, not processing time)
             self.frame_buffer.add_frame(frame_data, now, frame_number)
@@ -508,13 +549,18 @@ class BufferMonitor:
             # Update state machine
             events = self.state_machine.update(falcon_detected, now)
 
-            # Handle events
+            # Handle events. ARRIVED keeps deferring its surface to
+            # confirmation; DEPARTED/ROOSTING notifications and event-store
+            # rows now flow through the significance filter inside
+            # _handle_event (ho-09 / 025-B) — recording mechanics still run
+            # on the raw events immediately.
             for event_type, event_time, metadata in events:
-                # For arrival confirmation, don't notify immediately
-                # Skip notification for ARRIVED events (will notify after confirmation)
-                if event_type != FalconEvent.ARRIVED:
-                    self.event_handler.handle_event(event_type, event_time, metadata)
                 self._handle_event(event_type, event_time, metadata)
+
+            # Advance the significance filter once per poll: release held
+            # departures whose merge window expired and emit due damping
+            # summaries (025-B).
+            self._execute_decisions(self.significance_filter.tick(now))
 
         except Exception as e:
             logger.error(f"❌ Error processing frame {frame_number}: {e}", exc_info=True)
@@ -724,6 +770,7 @@ class BufferMonitor:
                 # never work here: event_time is last_detection, which is
                 # ≥ exit_timeout in the past — always outside the buffer.
                 departure_clip_scheduled = self._finalize_departure_candidate(event_time)
+                visit_row: FalconVisit | None = None
                 if self._roosting_visit_metadata and "visit_start" in metadata:
                     visit_start_dt = metadata["visit_start"]
                     if isinstance(visit_start_dt, str):
@@ -745,7 +792,7 @@ class BufferMonitor:
                     departure_clip_path = get_output_path(
                         self.clips_dir, visit_end_dt, "departure", "mp4"
                     )
-                    visit = FalconVisit(
+                    visit_row = FalconVisit(
                         start_time=metadata["visit_start"],
                         end_time=last_detection_time,
                         peak_confidence=self._visit_peak_confidence,
@@ -757,7 +804,6 @@ class BufferMonitor:
                             str(departure_clip_path) if departure_clip_scheduled else None
                         ),
                     )
-                    self.event_store.append(visit)
                 self._visit_peak_confidence = 0.0
                 self.roosting_mode_active = False
                 self.last_roosting_check = None
@@ -765,6 +811,9 @@ class BufferMonitor:
                 # Roosting mode over — reset candidate poll tracking (022-C).
                 # The candidate itself was consumed by the finalize above.
                 self._roosting_last_poll_detected = False
+                # Surface (notification + event-store row) flows through the
+                # significance filter (ho-09 / 025-B)
+                self._route_departure_surface(event_time, metadata, visit_row)
                 return
 
             # Stop recording and create clips
@@ -772,6 +821,7 @@ class BufferMonitor:
 
             visit_path, visit_metadata = self.visit_recorder.stop_recording(event_time)
 
+            visit_row = None
             if visit_path and visit_metadata:
                 # Use last_detection_time from state machine instead of departure_time
                 # This ensures departure clip shows actual departure, not empty nest
@@ -815,7 +865,7 @@ class BufferMonitor:
                         self.clips_dir, visit_end_dt, "departure", "mp4"
                     )
 
-                    visit = FalconVisit(
+                    visit_row = FalconVisit(
                         start_time=metadata["visit_start"],
                         end_time=metadata["visit_end"],
                         peak_confidence=self._visit_peak_confidence,
@@ -827,13 +877,18 @@ class BufferMonitor:
                             str(departure_clip_path) if departure_clip_scheduled else None
                         ),
                     )
-                    self.event_store.append(visit)
 
                     duration = visit_metadata.get("duration_seconds", 0)
                     logger.event(f"✅ Visit recorded: {duration:.0f}s → {visit_path}")
 
             # Visit is over — reset the visit-scoped peak (022-A)
             self._visit_peak_confidence = 0.0
+
+            # Surface (notification + event-store row) flows through the
+            # significance filter (ho-09 / 025-B). Runs even without a row —
+            # the departure notification does not depend on the recorder
+            # having produced a visit file.
+            self._route_departure_surface(event_time, metadata, visit_row)
 
         elif event_type == FalconEvent.ROOSTING:
             if self.roosting_recording_mode == "stop":
@@ -859,6 +914,142 @@ class BufferMonitor:
                         metadata,
                     )
 
+            # ROOSTING surface passes through the filter untouched (ho-09):
+            # notify=True, no event-store row — same as today, one path.
+            self._execute_decisions(
+                self.significance_filter.process(
+                    (event_type, event_time, metadata), self._frame_now or event_time
+                )
+            )
+
+    def _route_departure_surface(
+        self,
+        event_time: datetime,
+        metadata: dict,
+        visit_row: FalconVisit | None,
+    ) -> None:
+        """Route a DEPARTED's surface through the significance filter (025-B).
+
+        Recording mechanics have already run on the raw event. The segment
+        row merges into the pending row; the filter decides when (and how)
+        the row and the departure notification surface.
+
+        Args:
+            event_time: The DEPARTED event time (visit_end).
+            metadata: The raw state-machine event metadata.
+            visit_row: The segment's FalconVisit row, or None when the
+                recorder produced no visit file.
+        """
+        self._merge_pending_visit_row(visit_row)
+        now = self._frame_now or event_time
+        decisions = self.significance_filter.process(
+            (FalconEvent.DEPARTED, event_time, metadata), now
+        )
+        self._execute_decisions(decisions)
+
+    def _merge_pending_visit_row(self, visit_row: FalconVisit | None) -> None:
+        """Merge a departure segment's row into the pending visit row (025-B).
+
+        The row is the unit of meaning, the files the unit of storage: a
+        continuation segment extends the pending row's span, takes the max
+        peak confidence, and supplies the (new) departure clip; the arrival
+        clip, thumbnail, start time, and id stay with the first segment.
+        """
+        if visit_row is None:
+            return
+        if self._pending_visit_row is None:
+            self._pending_visit_row = visit_row
+            return
+
+        pending = self._pending_visit_row
+        pending.end_time = visit_row.end_time
+        pending.peak_confidence = max(pending.peak_confidence, visit_row.peak_confidence)
+        pending.departure_clip_path = visit_row.departure_clip_path
+
+    def _execute_decisions(self, decisions: list[FilterDecision]) -> None:
+        """Execute significance-filter decisions (025-B)."""
+        for decision in decisions:
+            self._execute_decision(decision)
+
+    def _execute_decision(self, decision: FilterDecision) -> None:
+        """Execute one significance-filter decision.
+
+        Notifications go through the event handler; released departure rows
+        pick up the filter's flags before the event-store append. Swallowed
+        continuation arrivals (discard_arrival_clip) are zero-surface here —
+        their clip discard happens at the confirmation site, where the
+        recorder still holds the file.
+        """
+        if decision.is_summary:
+            self._send_activity_summary(decision)
+            return
+
+        if decision.discard_arrival_clip:
+            return
+
+        if decision.event_type == FalconEvent.DEPARTED:
+            if decision.notify:
+                self.event_handler.handle_event(
+                    FalconEvent.DEPARTED, decision.event_time, decision.metadata
+                )
+            row = self._pending_visit_row
+            self._pending_visit_row = None
+            if row is not None:
+                row.insignificant = decision.insignificant
+                row.merged_segments = decision.merged_segments
+                if decision.record:
+                    self.event_store.append(row)
+        elif decision.event_type is not None and decision.notify:
+            self.event_handler.handle_event(
+                decision.event_type, decision.event_time, decision.metadata
+            )
+
+    def _send_activity_summary(self, decision: FilterDecision) -> None:
+        """Send a damped-mode activity summary notification (ho-09 / 025-B)."""
+        count = decision.metadata.get("count", 0)
+        median_str = format_duration(decision.metadata.get("median_duration_seconds", 0.0))
+        window_hours = decision.metadata.get("window_hours", 1)
+        window_str = f"{window_hours:g} hour" + ("s" if window_hours != 1 else "")
+        message = f"🦅 Busy nest: {count} visits in the last {window_str} (median {median_str})"
+        logger.event(f"📊 Activity summary: {message}")
+
+        notifications = self.event_handler.notifications
+        if notifications:
+            notifications.send_activity_summary(message)
+
+    def _discard_continuation_arrival_clip(self, now: datetime) -> None:
+        """Discard the continuation's arrival clip on a merged re-arrival (025-B).
+
+        Called at confirmation time, when the arrival clip recorder is
+        normally still writing: stop it without renaming and delete the .tmp
+        (plus any already-final clip/thumbnail for that arrival, defensively).
+        Data is not lost — the visit recording continues; only the redundant
+        arrival clip of a continuation segment goes.
+
+        Args:
+            now: The driving frame timestamp.
+        """
+        tmp_path = self.arrival_clip_recorder.get_temp_path()
+        final_paths: list[Path] = []
+        if self.arrival_pending_start is not None:
+            final_paths = [
+                get_output_path(self.clips_dir, self.arrival_pending_start, "arrival", "mp4"),
+                get_output_path(self.clips_dir, self.arrival_pending_start, "arrival", "jpg"),
+            ]
+
+        if self.arrival_clip_recorder.is_recording():
+            self.arrival_clip_recorder.stop_recording(now)
+
+        for path in [tmp_path, *final_paths]:
+            if path and path.exists():
+                try:
+                    path.unlink()
+                    logger.debug(f"Deleted continuation arrival file: {path.name}")
+                except OSError as e:
+                    logger.warning(f"Could not delete continuation arrival file {path.name}: {e}")
+
+        logger.event("🔗 Continuation arrival clip discarded (merged visit)")
+
     def _confirm_arrival(self) -> None:
         """Confirm arrival after passing detection threshold."""
         ratio = self.arrival_detection_count / self.arrival_frame_count
@@ -867,15 +1058,33 @@ class BufferMonitor:
             f"({self.arrival_detection_count}/{self.arrival_frame_count} frames)"
         )
 
-        # Rename arrival clip from .tmp to final
-        self.arrival_clip_recorder.rename_to_final()
+        # Route the confirmed arrival through the significance filter
+        # (ho-09 / 025-B): a re-arrival inside the merge window is a
+        # continuation — no notification, arrival clip discarded.
+        decisions: list[FilterDecision] = []
+        if self.arrival_pending_start is not None:
+            now = self._frame_now or self.arrival_pending_start
+            decisions = self.significance_filter.process(
+                (FalconEvent.ARRIVED, self.arrival_pending_start, {}), now
+            )
+
+        if any(d.discard_arrival_clip for d in decisions):
+            # Continuation of a merged visit: drop the arrival clip instead
+            # of finalizing it. The visit recording still finalizes below —
+            # a merged visit may span multiple visit files by design.
+            self._discard_continuation_arrival_clip(
+                self._frame_now or self.arrival_pending_start or get_now_tz(self.full_config)
+            )
+        else:
+            # Rename arrival clip from .tmp to final
+            self.arrival_clip_recorder.rename_to_final()
 
         # Rename visit recording from .tmp to final
         self.visit_recorder.rename_to_final()
 
-        # NOW send notification and handle event
-        if self.arrival_pending_start is not None:
-            self.event_handler.handle_event(FalconEvent.ARRIVED, self.arrival_pending_start, {})
+        # NOW send the notification — if the filter's decision says so
+        # (pass-through when the filter is disabled)
+        self._execute_decisions(decisions)
 
         # Reset pending state
         self.arrival_pending = False
@@ -954,12 +1163,17 @@ class BufferMonitor:
         # Transition from PENDING_STARTUP to ROOSTING
         self.state_machine.confirm_startup_presence(now)
 
-        # Send notification only if notify_on_startup is enabled
+        # Send notification only if notify_on_startup is enabled — routed
+        # through the significance filter like every confirmed arrival
+        # (ho-09 / 025-B; nothing is ever held at startup, so this is a
+        # pass-through that also seeds the damping arrival count)
         if self.notify_on_startup and self.startup_pending_start is not None:
             logger.info("📲 Sending startup arrival notification")
-            self.event_handler.handle_event(
-                FalconEvent.ARRIVED, self.startup_pending_start, {"startup": True}
+            decisions = self.significance_filter.process(
+                (FalconEvent.ARRIVED, self.startup_pending_start, {"startup": True}),
+                now,
             )
+            self._execute_decisions(decisions)
         else:
             logger.info("📴 Skipping startup arrival notification (notify_on_startup=false)")
 
@@ -1055,9 +1269,10 @@ class BufferMonitor:
         # Tracker resets with the state machine (ho-12 / 024-C)
         self._reset_presence()
 
-        # Handle deparure event (create clips, notify, etc.)
+        # Handle departure event (create clips; the notification and row
+        # flow through the significance filter inside _handle_event, 025-B)
+        self._frame_now = now
         for event_type, event_time, metadata in events:
-            self.event_handler.handle_event(event_type, event_time, metadata)
             self._handle_event(event_type, event_time, metadata)
 
         # Reset recovery pending state
@@ -1448,6 +1663,11 @@ class BufferMonitor:
                 self.arrival_clip_recorder.stop_recording(now)
                 logger.info("✅ Final arrival clip saved")
 
+            # Flush any held significance-filter decision so no row is lost
+            # on SIGTERM (ho-09 / 025-B): a departure held for its merge
+            # window is released immediately at shutdown.
+            self._execute_decisions(self.significance_filter.flush(get_now_tz(self.full_config)))
+
             # Clean up an outstanding departure-candidate clip (022-C) —
             # no orphan .tmp files across restarts.
             self._discard_departure_candidate()
@@ -1528,6 +1748,11 @@ def main():
             presence_motion_min_area_frac=config.get("presence_motion_min_area_frac", 0.02),
             presence_global_change_frac=config.get("presence_global_change_frac", 0.5),
             presence_absence_failsafe_seconds=config.get("presence_absence_failsafe_seconds", 3600),
+            significance_filter_enabled=config.get("significance_filter_enabled", True),
+            merge_window_seconds=config.get("merge_window_seconds", 300),
+            min_significant_seconds=config.get("min_significant_seconds", 30),
+            damping_arrivals_threshold=config.get("damping_arrivals_threshold", 8),
+            damping_window_hours=config.get("damping_window_hours", 1),
             notify_on_startup=config.get("notify_on_startup", True),
             record_arrival_on_startup=config.get("record_arrival_on_startup", False),
             max_runtime_seconds=config.get("max_runtime_seconds"),

--- a/src/kanyo/detection/events.py
+++ b/src/kanyo/detection/events.py
@@ -55,6 +55,10 @@ class FalconVisit:
     thumbnail_path: str | None = None
     arrival_clip_path: str | None = None
     departure_clip_path: str | None = None
+    # Significance filter surface flags (ho-09 / 025-B). Additive with safe
+    # defaults so existing rows and to_dict() consumers are unaffected.
+    insignificant: bool = False  # below min_significant_seconds: recorded log-only
+    merged_segments: int = 1  # >= 2 when this row spans merged visit segments
     id: str = field(default="")
 
     def __post_init__(self):
@@ -104,6 +108,8 @@ class FalconVisit:
             "thumbnail_path": self.thumbnail_path,
             "arrival_clip_path": self.arrival_clip_path,
             "departure_clip_path": self.departure_clip_path,
+            "insignificant": self.insignificant,
+            "merged_segments": self.merged_segments,
         }
 
 

--- a/src/kanyo/utils/config.py
+++ b/src/kanyo/utils/config.py
@@ -49,6 +49,12 @@ DEFAULTS: dict[str, Any] = {
     "presence_motion_min_area_frac": 0.02,  # changed fraction of region to count as motion
     "presence_global_change_frac": 0.5,  # whole-frame change above this = discard motion evidence
     "presence_absence_failsafe_seconds": 3600,  # zero-evidence ceiling before forced absence
+    # Significance Filter (ho-09)
+    "significance_filter_enabled": True,  # master switch; false = today's behavior
+    "merge_window_seconds": 300,  # DEPARTED→ARRIVED within this = same visit (0 disables)
+    "min_significant_seconds": 30,  # below this detection-duration: log-only (0 disables)
+    "damping_arrivals_threshold": 8,  # arrivals per window to enter damped mode (0 disables)
+    "damping_window_hours": 1,  # rolling window for the arrival count
     # Output & Storage
     "output_dir": "output",  # results directory
     "data_dir": "data",  # thumbnails, events, etc.
@@ -276,13 +282,40 @@ def _validate(cfg: dict[str, Any]) -> None:
             f"Consider increasing clip_departure_before or clip_departure_after."
         )
 
-    # short_visit_threshold should be reasonable
+    # short_visit_threshold is deprecated (ho-09): validated here but consumed
+    # nowhere in the detection path. min_significant_seconds (significance
+    # filter) supersedes it. The range check is kept so existing configs keep
+    # their load-time guarantees until the key is removed.
+    if "short_visit_threshold" in cfg:
+        logger.warning(
+            "⚠️  short_visit_threshold is deprecated and has no effect — "
+            "use min_significant_seconds (significance filter) instead"
+        )
     short_visit_threshold = cfg.get("short_visit_threshold", 600)
     if short_visit_threshold < 60:
         raise ValueError(
             f"short_visit_threshold ({short_visit_threshold}s) is too short. "
             f"Minimum recommended value is 60 seconds."
         )
+
+    # Significance filter validation (ho-09 / 025-B)
+    merge_window = cfg.get("merge_window_seconds", DEFAULTS["merge_window_seconds"])
+    if not isinstance(merge_window, (int, float)) or merge_window < 0:
+        raise ValueError("merge_window_seconds must be >= 0 (0 disables merging)")
+
+    min_significant = cfg.get("min_significant_seconds", DEFAULTS["min_significant_seconds"])
+    if not isinstance(min_significant, (int, float)) or min_significant < 0:
+        raise ValueError("min_significant_seconds must be >= 0 (0 disables the significance gate)")
+
+    damping_threshold = cfg.get(
+        "damping_arrivals_threshold", DEFAULTS["damping_arrivals_threshold"]
+    )
+    if not isinstance(damping_threshold, int) or damping_threshold < 0:
+        raise ValueError("damping_arrivals_threshold must be an integer >= 0 (0 disables damping)")
+
+    damping_window = cfg.get("damping_window_hours", DEFAULTS["damping_window_hours"])
+    if not isinstance(damping_window, (int, float)) or damping_window <= 0:
+        raise ValueError("damping_window_hours must be a positive number of hours")
 
     # Presence layer validation (ho-12 / 024-C)
     presence_fraction_keys = (

--- a/src/kanyo/utils/notifications.py
+++ b/src/kanyo/utils/notifications.py
@@ -155,6 +155,65 @@ class NotificationManager:
 
         return success
 
+    def send_activity_summary(self, message: str) -> bool:
+        """
+        Send an activity summary to Telegram (significance filter damped mode, ho-09).
+
+        Summaries replace individual arrival/departure notifications while the
+        arrival rate is above the damping threshold. Text-only — no photo, and
+        no cooldown interaction (summaries are already rate-limited to one per
+        damping window by the filter).
+
+        Args:
+            message: Summary text (e.g. "9 visits in the last hour, median 25s")
+
+        Returns:
+            True if sent, False if disabled or failed
+        """
+        if not self.telegram_enabled:
+            return False
+        return self._send_telegram_text(message)
+
+    def _send_telegram_text(self, text: str) -> bool:
+        """
+        Send a text-only message to the Telegram channel.
+
+        Args:
+            text: Message text
+
+        Returns:
+            True if sent successfully, False otherwise
+        """
+        try:
+            url = f"https://api.telegram.org/bot{self.telegram_token}/sendMessage"
+            data = {
+                "chat_id": self.telegram_channel,
+                "text": text,
+            }
+            resp = requests.post(url, data=data, timeout=10)
+
+            if resp.status_code == 200:
+                logger.event(f"📧 Telegram sent: {text}")
+                return True
+
+            error_msg = resp.text[:200]
+            logger.error(f"❌ Telegram API error {resp.status_code}: {error_msg}")
+            self._send_admin_error(f"Telegram delivery failed: {resp.status_code}")
+            return False
+
+        except requests.Timeout:
+            logger.error(f"❌ Telegram timeout (10s): {text}")
+            self._send_admin_error("Telegram delivery timeout")
+            return False
+        except requests.ConnectionError as e:
+            logger.error(f"❌ Telegram connection error: {e}")
+            self._send_admin_error(f"Telegram connection failed: {e}")
+            return False
+        except Exception as e:
+            logger.error(f"❌ Telegram unexpected error: {e}")
+            self._send_admin_error(f"Telegram error: {e}")
+            return False
+
     def _send_telegram_photo(self, caption: str, photo_path: Path | str | None) -> bool:
         """
         Send photo message to Telegram channel.

--- a/tests/test_significance_integration.py
+++ b/tests/test_significance_integration.py
@@ -1,0 +1,420 @@
+"""Integration tests for the significance filter in buffer_monitor (ho-09 / 025-B).
+
+Recording mechanics run on raw events; notifications and event-store rows
+flow through EventSignificanceFilter decisions. With the filter disabled the
+routing is identical to the pre-filter behavior.
+"""
+
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kanyo.detection.buffer_monitor import BufferMonitor
+from kanyo.detection.event_types import FalconEvent
+from kanyo.detection.events import FalconVisit
+from kanyo.utils.config import DEFAULTS, _validate
+from kanyo.utils.output import get_output_path
+
+T0 = datetime(2026, 7, 16, 10, 0, 0)
+
+
+def ts(seconds: float) -> datetime:
+    return T0 + timedelta(seconds=seconds)
+
+
+def make_monitor(
+    clips_dir: str = "clips",
+    significance_filter_enabled: bool = True,
+    merge_window_seconds: float = 300,
+    min_significant_seconds: float = 30,
+    damping_arrivals_threshold: int = 8,
+    damping_window_hours: float = 1,
+):
+    """Return a BufferMonitor with all external dependencies mocked out."""
+    with (
+        patch("kanyo.detection.buffer_monitor.StreamCapture"),
+        patch("kanyo.detection.buffer_monitor.FalconDetector"),
+        patch("kanyo.detection.buffer_monitor.FrameBuffer"),
+        patch("kanyo.detection.buffer_monitor.VisitRecorder"),
+        patch("kanyo.detection.buffer_monitor.BufferClipManager"),
+        patch("kanyo.detection.buffer_monitor.EventStore"),
+        patch("kanyo.detection.buffer_monitor.FalconEventHandler"),
+        patch("kanyo.detection.buffer_monitor.FalconStateMachine"),
+        patch("kanyo.detection.buffer_monitor.ArrivalClipRecorder"),
+    ):
+        monitor = BufferMonitor(
+            stream_url="test",
+            clips_dir=clips_dir,
+            presence_enabled=False,
+            significance_filter_enabled=significance_filter_enabled,
+            merge_window_seconds=merge_window_seconds,
+            min_significant_seconds=min_significant_seconds,
+            damping_arrivals_threshold=damping_arrivals_threshold,
+            damping_window_hours=damping_window_hours,
+            full_config={},
+        )
+    return monitor
+
+
+def drive_departure(monitor, visit_start: datetime, visit_end: datetime) -> None:
+    """Run a normal DEPARTED through _handle_event with mocked mechanics.
+
+    The event time is visit_end (state-machine semantics) and the frame time
+    is set to visit_end so the merge window runs its full length in tests.
+    """
+    monitor.arrival_pending = False
+    monitor.arrival_clip_recorder.is_recording.return_value = False
+    monitor.visit_recorder.stop_recording.return_value = (
+        "/fake/visit.mp4",
+        {"visit_start": visit_start, "duration_seconds": 0},
+    )
+    monitor.clip_manager.create_departure_clip.return_value = True
+
+    metadata = {
+        "visit_start": visit_start,
+        "visit_end": visit_end,
+        "visit_duration_seconds": (visit_end - visit_start).total_seconds(),
+    }
+    monitor._frame_now = visit_end
+    monitor._handle_event(FalconEvent.DEPARTED, visit_end, metadata)
+
+
+def confirm_arrival(monitor, arrival_time: datetime, now: datetime | None = None) -> None:
+    """Run a confirmed arrival through _confirm_arrival."""
+    monitor.arrival_pending = True
+    monitor.arrival_pending_start = arrival_time
+    monitor.arrival_detection_count = 5
+    monitor.arrival_frame_count = 10
+    monitor.arrival_clip_recorder.get_temp_path.return_value = None
+    monitor.arrival_clip_recorder.is_recording.return_value = False
+    monitor._frame_now = now or arrival_time
+    monitor._confirm_arrival()
+
+
+def tick(monitor, now: datetime) -> None:
+    """Advance the filter as process_frame does once per poll."""
+    monitor._frame_now = now
+    monitor._execute_decisions(monitor.significance_filter.tick(now))
+
+
+def departed_notifications(monitor) -> list:
+    return [
+        c
+        for c in monitor.event_handler.handle_event.call_args_list
+        if c.args[0] == FalconEvent.DEPARTED
+    ]
+
+
+def arrived_notifications(monitor) -> list:
+    return [
+        c
+        for c in monitor.event_handler.handle_event.call_args_list
+        if c.args[0] == FalconEvent.ARRIVED
+    ]
+
+
+class TestDisabledPassThrough:
+    """significance_filter_enabled=false → routing identical to today."""
+
+    def test_departure_surfaces_immediately(self, tmp_path):
+        monitor = make_monitor(clips_dir=str(tmp_path), significance_filter_enabled=False)
+
+        drive_departure(monitor, ts(0), ts(20))  # even a 20s visit
+
+        monitor.event_store.append.assert_called_once()
+        row = monitor.event_store.append.call_args[0][0]
+        assert isinstance(row, FalconVisit)
+        assert row.insignificant is False
+        assert row.merged_segments == 1
+        assert len(departed_notifications(monitor)) == 1
+        notification = departed_notifications(monitor)[0]
+        assert notification.args[1] == ts(20)
+        assert notification.args[2]["visit_start"] == ts(0)
+
+    def test_confirmed_arrival_notifies_immediately(self, tmp_path):
+        monitor = make_monitor(clips_dir=str(tmp_path), significance_filter_enabled=False)
+
+        confirm_arrival(monitor, ts(0))
+
+        assert len(arrived_notifications(monitor)) == 1
+        monitor.arrival_clip_recorder.rename_to_final.assert_called_once()
+        monitor.visit_recorder.rename_to_final.assert_called_once()
+
+    def test_rapid_pair_not_merged_when_disabled(self, tmp_path):
+        monitor = make_monitor(clips_dir=str(tmp_path), significance_filter_enabled=False)
+
+        drive_departure(monitor, ts(0), ts(600))
+        confirm_arrival(monitor, ts(720))
+        drive_departure(monitor, ts(720), ts(900))
+
+        assert monitor.event_store.append.call_count == 2
+        assert len(departed_notifications(monitor)) == 2
+        assert len(arrived_notifications(monitor)) == 1
+
+
+class TestMergedVisit:
+    def test_departed_then_rearrival_yields_one_merged_row(self, tmp_path):
+        monitor = make_monitor(clips_dir=str(tmp_path), merge_window_seconds=300)
+
+        # First segment departs — held: no row, no notification.
+        drive_departure(monitor, ts(0), ts(600))
+        monitor.event_store.append.assert_not_called()
+        assert departed_notifications(monitor) == []
+
+        # Re-arrival inside the window — swallowed: no arrival notification,
+        # arrival clip NOT finalized.
+        confirm_arrival(monitor, ts(720))
+        assert arrived_notifications(monitor) == []
+        monitor.arrival_clip_recorder.rename_to_final.assert_not_called()
+        # The visit recording still finalizes — files are the unit of storage.
+        monitor.visit_recorder.rename_to_final.assert_called_once()
+
+        # Second segment departs — still held.
+        drive_departure(monitor, ts(720), ts(900))
+        monitor.event_store.append.assert_not_called()
+
+        # Window expires: ONE merged row + ONE departure notification.
+        tick(monitor, ts(900 + 301))
+        monitor.event_store.append.assert_called_once()
+        row = monitor.event_store.append.call_args[0][0]
+        assert row.start_time == ts(0)
+        assert row.end_time == ts(900)
+        assert row.merged_segments == 2
+        assert row.insignificant is False
+        # Departure clip comes from the last segment.
+        expected_departure = str(get_output_path(str(tmp_path), ts(900), "departure", "mp4"))
+        assert row.departure_clip_path == expected_departure
+
+        notifications = departed_notifications(monitor)
+        assert len(notifications) == 1
+        assert notifications[0].args[2]["visit_start"] == ts(0)
+        assert notifications[0].args[2]["visit_duration_seconds"] == 900.0
+
+    def test_merged_row_takes_max_peak_confidence(self, tmp_path):
+        monitor = make_monitor(clips_dir=str(tmp_path), merge_window_seconds=300)
+
+        monitor._visit_peak_confidence = 0.9
+        drive_departure(monitor, ts(0), ts(600))
+        confirm_arrival(monitor, ts(700))
+        monitor._visit_peak_confidence = 0.4
+        drive_departure(monitor, ts(700), ts(900))
+
+        tick(monitor, ts(900 + 301))
+        row = monitor.event_store.append.call_args[0][0]
+        assert row.peak_confidence == 0.9
+
+    def test_continuation_arrival_clip_deleted(self, tmp_path):
+        """The swallowed arrival's clip file (still .tmp at confirmation) is
+        deleted instead of finalized."""
+        monitor = make_monitor(clips_dir=str(tmp_path), merge_window_seconds=300)
+        drive_departure(monitor, ts(0), ts(600))
+
+        clip_tmp = Path(tmp_path) / "arrival_clip.mp4.tmp"
+        clip_tmp.write_bytes(b"fake")
+        monitor.arrival_pending = True
+        monitor.arrival_pending_start = ts(720)
+        monitor.arrival_detection_count = 5
+        monitor.arrival_frame_count = 10
+        monitor.arrival_clip_recorder.get_temp_path.return_value = clip_tmp
+        monitor.arrival_clip_recorder.is_recording.return_value = True
+        monitor._frame_now = ts(720)
+        monitor._confirm_arrival()
+
+        monitor.arrival_clip_recorder.stop_recording.assert_called_once()
+        monitor.arrival_clip_recorder.rename_to_final.assert_not_called()
+        assert not clip_tmp.exists()
+
+    def test_lone_departure_released_at_expiry(self, tmp_path):
+        """No re-arrival: row + notification surface at window expiry,
+        content matching today's except timing."""
+        monitor = make_monitor(clips_dir=str(tmp_path), merge_window_seconds=300)
+
+        drive_departure(monitor, ts(0), ts(600))
+        tick(monitor, ts(600 + 300))  # boundary — still held
+        monitor.event_store.append.assert_not_called()
+
+        tick(monitor, ts(600 + 301))
+        monitor.event_store.append.assert_called_once()
+        row = monitor.event_store.append.call_args[0][0]
+        assert row.start_time == ts(0)
+        assert row.end_time == ts(600)
+        assert row.merged_segments == 1
+        assert len(departed_notifications(monitor)) == 1
+
+
+class TestInsignificantVisit:
+    def test_short_visit_row_flagged_no_notification(self, tmp_path):
+        monitor = make_monitor(
+            clips_dir=str(tmp_path), merge_window_seconds=300, min_significant_seconds=30
+        )
+
+        drive_departure(monitor, ts(0), ts(20))
+        tick(monitor, ts(20 + 301))
+
+        monitor.event_store.append.assert_called_once()
+        row = monitor.event_store.append.call_args[0][0]
+        assert row.insignificant is True
+        assert departed_notifications(monitor) == []
+
+
+class TestDamping:
+    def test_summary_replaces_individual_notifications(self, tmp_path):
+        monitor = make_monitor(
+            clips_dir=str(tmp_path),
+            merge_window_seconds=0,
+            min_significant_seconds=0,
+            damping_arrivals_threshold=2,
+            damping_window_hours=1,
+        )
+
+        for i in range(3):
+            confirm_arrival(monitor, ts(i * 60))
+        # First two arrivals notify; the third is damped.
+        assert len(arrived_notifications(monitor)) == 2
+
+        tick(monitor, ts(180))
+        monitor.event_handler.notifications.send_activity_summary.assert_called_once()
+        message = monitor.event_handler.notifications.send_activity_summary.call_args[0][0]
+        assert "3 visits" in message
+
+        # Two hours later the rate has dropped — notifications resume.
+        confirm_arrival(monitor, ts(2 * 3600))
+        assert len(arrived_notifications(monitor)) == 3
+
+
+class TestShutdownFlush:
+    def test_flush_writes_held_row(self, tmp_path):
+        """A held departure is released immediately at shutdown — no row is
+        lost on SIGTERM."""
+        monitor = make_monitor(clips_dir=str(tmp_path), merge_window_seconds=300)
+        drive_departure(monitor, ts(0), ts(600))
+        monitor.event_store.append.assert_not_called()
+
+        # The same wiring run()'s finally block executes:
+        monitor._execute_decisions(monitor.significance_filter.flush(ts(650)))
+
+        monitor.event_store.append.assert_called_once()
+        row = monitor.event_store.append.call_args[0][0]
+        assert row.start_time == ts(0)
+
+    def test_run_finally_flushes_filter(self):
+        """Source-level check that run()'s shutdown path flushes the filter."""
+        import inspect
+
+        source = inspect.getsource(BufferMonitor.run)
+        finally_block = source[source.find("finally:") :]
+        assert "significance_filter.flush" in finally_block, (
+            "run() must flush held significance-filter decisions on shutdown " "(ho-09 / 025-B)"
+        )
+
+
+class TestConstructionAndConfig:
+    def test_constructor_wires_filter(self):
+        monitor = make_monitor(
+            significance_filter_enabled=True,
+            merge_window_seconds=120,
+            min_significant_seconds=45,
+            damping_arrivals_threshold=6,
+            damping_window_hours=2,
+        )
+        filt = monitor.significance_filter
+        assert filt.enabled is True
+        assert filt.merge_window_seconds == 120
+        assert filt.min_significant_seconds == 45
+        assert filt.damping_arrivals_threshold == 6
+        assert filt.damping_window_hours == 2
+
+    def test_constructor_default_is_disabled(self):
+        """Direct construction keeps today's behavior; production configs
+        carry the enabled default via DEFAULTS."""
+        with (
+            patch("kanyo.detection.buffer_monitor.StreamCapture"),
+            patch("kanyo.detection.buffer_monitor.FalconDetector"),
+        ):
+            monitor = BufferMonitor(stream_url="test")
+        assert monitor.significance_filter.enabled is False
+
+    def test_defaults_carry_significance_keys(self):
+        assert DEFAULTS["significance_filter_enabled"] is True
+        assert DEFAULTS["merge_window_seconds"] == 300
+        assert DEFAULTS["min_significant_seconds"] == 30
+        assert DEFAULTS["damping_arrivals_threshold"] == 8
+        assert DEFAULTS["damping_window_hours"] == 1
+
+    def test_validation_rejects_negative_merge_window(self):
+        cfg = {"video_source": "x", "merge_window_seconds": -1}
+        with pytest.raises(ValueError, match="merge_window_seconds"):
+            _validate(cfg)
+
+    def test_validation_rejects_negative_min_significant(self):
+        cfg = {"video_source": "x", "min_significant_seconds": -5}
+        with pytest.raises(ValueError, match="min_significant_seconds"):
+            _validate(cfg)
+
+    def test_validation_rejects_bad_damping(self):
+        with pytest.raises(ValueError, match="damping_arrivals_threshold"):
+            _validate({"video_source": "x", "damping_arrivals_threshold": -1})
+        with pytest.raises(ValueError, match="damping_window_hours"):
+            _validate({"video_source": "x", "damping_window_hours": 0})
+
+    def test_zero_values_accepted(self):
+        _validate(
+            {
+                "video_source": "x",
+                "merge_window_seconds": 0,
+                "min_significant_seconds": 0,
+                "damping_arrivals_threshold": 0,
+            }
+        )
+
+    def test_short_visit_threshold_deprecation_warning(self, caplog):
+        with caplog.at_level("WARNING"):
+            _validate({"video_source": "x", "short_visit_threshold": 600})
+        assert any("short_visit_threshold is deprecated" in r.message for r in caplog.records)
+
+    def test_no_deprecation_warning_when_key_absent(self, caplog):
+        with caplog.at_level("WARNING"):
+            _validate({"video_source": "x"})
+        assert not any("short_visit_threshold" in r.message for r in caplog.records)
+
+
+class TestVisitRowFlags:
+    def test_to_dict_serializes_new_flags(self):
+        visit = FalconVisit(
+            start_time=T0,
+            end_time=ts(300),
+            insignificant=True,
+            merged_segments=3,
+        )
+        d = visit.to_dict()
+        assert d["insignificant"] is True
+        assert d["merged_segments"] == 3
+
+    def test_flags_default_safe(self):
+        visit = FalconVisit(start_time=T0, end_time=ts(300))
+        d = visit.to_dict()
+        assert d["insignificant"] is False
+        assert d["merged_segments"] == 1
+
+
+class TestTickWiredIntoProcessFrame:
+    def test_process_frame_ticks_the_filter(self, tmp_path):
+        """A held departure is released by process_frame's per-poll tick."""
+        monitor = make_monitor(clips_dir=str(tmp_path), merge_window_seconds=300)
+        drive_departure(monitor, ts(0), ts(600))
+        monitor.event_store.append.assert_not_called()
+
+        # Quiet frame past the window: no events, tick releases the hold.
+        monitor.visit_recorder.is_recording = False
+        monitor.arrival_clip_recorder.is_recording.return_value = False
+        monitor.frame_buffer.add_frame.return_value = None
+        monitor.state_machine.update.return_value = []
+        monitor.detector.detect_birds.return_value = []
+        frame = MagicMock()
+        frame.shape = (720, 1280, 3)
+
+        monitor.process_frame(frame, frame_number=1, timestamp=ts(600 + 301))
+
+        monitor.event_store.append.assert_called_once()


### PR DESCRIPTION
Wires the ho-09 significance filter into the pipeline (agent task 025-B). Depends on #41.

## What

- **Routing split** (`buffer_monitor`): recording/clip mechanics keep running on raw state-machine events; notifications and `event_store.append` now flow through `EventSignificanceFilter` decisions. Confirmed arrivals (`_confirm_arrival`, startup path) enter the filter; DEPARTED rows are built as before but held/merged/released by filter decisions; `tick` runs once per processed frame; held decisions flush in `run()`'s finally so no row is lost on SIGTERM.
- **Merge behavior**: a re-arrival inside the merge window is a continuation — no notifications for the swallowed pair, the continuation's arrival clip (still .tmp at confirmation) is deleted instead of finalized, and one merged row spans first `visit_start` to last `visit_end` (arrival clip/thumbnail from the first segment, departure clip from the last, max peak confidence).
- **FalconVisit**: additive `insignificant` / `merged_segments` fields, serialized with safe defaults.
- **Config**: five new keys in `DEFAULTS` + validation (0 values disable the respective behavior); `short_visit_threshold` (validated but consumed nowhere) deprecated with a load-time warning and removed from the template; new documented "Significance Filter" template section (per-cam tuning guidance, late-departure-notification note).
- **Notifications**: `send_activity_summary` — text-only Telegram send for damped-mode summaries.

## Integration decisions

- `BufferMonitor` constructor defaults the filter **off** (config `DEFAULTS` carry `significance_filter_enabled: true`, wired via `main()`): direct construction keeps today's surface byte-identical, which is what keeps the existing test suite green unmodified.
- `_handle_event` keeps its 3-arg signature (test spies wrap it); the driving frame time reaches the filter via `_frame_now` with event-time fallback.
- A DEPARTED that lands while an arrival is pending still cancels the arrival with no surface (mirrors the existing early-return; the old unconditional pre-notification on that practically-unreachable path is gone).

## Verification

- `mypy src/` clean; touched files black/isort clean.
- New `tests/test_significance_integration.py`: 23 tests (disabled pass-through, merge + clip discard, insignificance, damping summary, SIGTERM flush, config validation/deprecation).
- Full suite: 464 passed; only the 4 known pre-existing failures. Existing tests unmodified.