### PR TITLE
Coverage campaign: src/kanyo 78% -> 100%, floor enforced at 95%

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,16 @@ extend-exclude = '''
 profile = "black"
 line_length = 100
 
+[tool.coverage.report]
+# Coverage floor for src/kanyo, enforced at every pytest run (pytest.ini --cov).
+fail_under = 95
+exclude_also = [
+    # Static-typing-only imports never execute at runtime
+    "if TYPE_CHECKING:",
+    # CLI entry blocks are exercised manually, not under pytest
+    "if __name__ == .__main__.:",
+]
+
 [tool.mypy]
 python_version = "3.10"
 mypy_path = "src"

--- a/tests/test_arrival_clip_recorder.py
+++ b/tests/test_arrival_clip_recorder.py
@@ -1,0 +1,212 @@
+"""Tests for arrival clip recorder module."""
+
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest.mock import Mock
+
+from kanyo.utils.arrival_clip_recorder import ArrivalClipRecorder
+
+
+def make_clip_manager() -> Mock:
+    """Mock BufferClipManager with the timing attributes the recorder reads."""
+    manager = Mock()
+    manager.clip_arrival_before = 15
+    manager.clip_arrival_after = 30
+    manager.clip_fps = 30
+    return manager
+
+
+def make_inner_recorder(final_path=None) -> Mock:
+    """Mock VisitRecorder whose stop_recording returns the given final path."""
+    inner = Mock()
+    inner.stop_recording.return_value = (final_path, {})
+    return inner
+
+
+class TestIsRecording:
+    """Tests for the is_recording state check."""
+
+    def test_not_recording_initially(self):
+        """A fresh recorder is idle."""
+        acr = ArrivalClipRecorder(make_clip_manager())
+        assert acr.is_recording() is False
+
+    def test_recording_when_recorder_active(self):
+        """An active inner recorder means a clip is in flight."""
+        acr = ArrivalClipRecorder(make_clip_manager())
+        acr._recorder = Mock()
+        assert acr.is_recording() is True
+
+
+class TestStartRecording:
+    """Tests for start_recording outcomes."""
+
+    def test_returns_false_when_clip_creation_fails(self):
+        """If the clip manager can't start ffmpeg, no recording state is kept."""
+        manager = make_clip_manager()
+        manager.create_standalone_arrival_clip.return_value = (None, None)
+        acr = ArrivalClipRecorder(manager)
+
+        result = acr.start_recording(
+            arrival_time=datetime(2026, 1, 3, 10, 0, 0),
+            lead_in_frames=[],
+            frame_size=(1280, 720),
+        )
+
+        assert result is False
+        assert acr.is_recording() is False
+
+    def test_success_initializes_frame_budget(self):
+        """Frame budget is duration * fps; lead-in frames count as already written."""
+        manager = make_clip_manager()
+        manager.create_standalone_arrival_clip.return_value = (
+            Path("/fake/arrival.mp4.tmp"),
+            make_inner_recorder(),
+        )
+        acr = ArrivalClipRecorder(manager)
+
+        lead_in = [Mock(), Mock(), Mock()]
+        result = acr.start_recording(
+            arrival_time=datetime(2026, 1, 3, 10, 0, 0),
+            lead_in_frames=lead_in,
+            frame_size=(1280, 720),
+        )
+
+        assert result is True
+        assert acr._frames_written == 3
+        assert acr._max_frames == 45 * 30  # (before + after) * fps
+        assert acr._max_duration_seconds == 45.0
+
+
+class TestWriteFrame:
+    """Tests for write_frame stop conditions."""
+
+    def test_ignored_when_not_recording(self):
+        """Frames arriving while idle are dropped without error."""
+        acr = ArrivalClipRecorder(make_clip_manager())
+
+        acr.write_frame(Mock(), datetime(2026, 1, 3, 10, 0, 1))
+
+        assert acr._frames_written == 0
+        assert acr.is_recording() is False
+
+    def test_stops_on_frame_count_fallback(self):
+        """When wall-clock hasn't elapsed, the frame-count budget still closes the clip."""
+        acr = ArrivalClipRecorder(make_clip_manager())
+        inner = make_inner_recorder()
+        acr._recorder = inner
+        acr._clip_path = Path("/fake/arrival.mp4.tmp")
+        acr._max_frames = 2
+        acr._max_duration_seconds = 45.0
+        start = datetime(2026, 1, 3, 10, 0, 0)
+        acr._start_time = start
+
+        acr.write_frame(Mock(), start + timedelta(seconds=1))
+        assert acr.is_recording() is True
+
+        acr.write_frame(Mock(), start + timedelta(seconds=2))
+
+        inner.stop_recording.assert_called_once()
+        assert acr.is_recording() is False
+
+
+class TestStopRecording:
+    """Tests for stop_recording finalization."""
+
+    def test_noop_when_not_recording(self):
+        """Stopping an idle recorder does nothing."""
+        acr = ArrivalClipRecorder(make_clip_manager())
+
+        acr.stop_recording(datetime(2026, 1, 3, 10, 0, 45))  # Must not raise
+
+        assert acr.is_recording() is False
+
+    def test_uses_final_path_and_deletes_ffmpeg_log(self, tmp_path):
+        """The renamed final path wins, and its ffmpeg log is cleaned up."""
+        final_path = tmp_path / "falcon_100000_000000_arrival.mp4"
+        final_path.write_text("clip")
+        ffmpeg_log = final_path.with_suffix(".ffmpeg.log")
+        ffmpeg_log.write_text("ffmpeg output")
+
+        acr = ArrivalClipRecorder(make_clip_manager())
+        acr._recorder = make_inner_recorder(final_path=final_path)
+        acr._clip_path = final_path.with_suffix(".mp4.tmp")
+        acr._frames_written = 10
+
+        acr.stop_recording(datetime(2026, 1, 3, 10, 0, 45))
+
+        assert not ffmpeg_log.exists()
+        assert acr.is_recording() is False
+        assert acr._clip_path is None
+        assert acr._frames_written == 0
+
+    def test_survives_undeletable_ffmpeg_log(self, tmp_path):
+        """A log that can't be unlinked is logged and skipped, not fatal."""
+        final_path = tmp_path / "falcon_100000_000000_arrival.mp4"
+        final_path.write_text("clip")
+        # A directory at the log path makes unlink() raise
+        ffmpeg_log = final_path.with_suffix(".ffmpeg.log")
+        ffmpeg_log.mkdir()
+
+        acr = ArrivalClipRecorder(make_clip_manager())
+        acr._recorder = make_inner_recorder(final_path=final_path)
+        acr._clip_path = final_path.with_suffix(".mp4.tmp")
+
+        acr.stop_recording(datetime(2026, 1, 3, 10, 0, 45))  # Must not raise
+
+        assert ffmpeg_log.exists()
+        assert acr.is_recording() is False
+
+    def test_falls_back_to_tmp_path_when_no_final_path(self, tmp_path):
+        """Without a rename, cleanup targets the .tmp clip path."""
+        clip_path = tmp_path / "falcon_100000_000000_arrival.mp4.tmp"
+        clip_path.write_text("clip")
+        ffmpeg_log = clip_path.with_suffix(".ffmpeg.log")
+        ffmpeg_log.write_text("ffmpeg output")
+
+        acr = ArrivalClipRecorder(make_clip_manager())
+        acr._recorder = make_inner_recorder(final_path=None)
+        acr._clip_path = clip_path
+
+        acr.stop_recording(datetime(2026, 1, 3, 10, 0, 45))
+
+        assert not ffmpeg_log.exists()
+        assert acr.is_recording() is False
+
+
+class TestRenameToFinal:
+    """Tests for rename_to_final delegation."""
+
+    def test_delegates_to_inner_recorder(self):
+        """An active recording delegates the rename to the visit recorder."""
+        acr = ArrivalClipRecorder(make_clip_manager())
+        inner = Mock()
+        inner.rename_to_final.return_value = Path("/fake/arrival.mp4")
+        acr._recorder = inner
+
+        assert acr.rename_to_final() == Path("/fake/arrival.mp4")
+        inner.rename_to_final.assert_called_once()
+
+    def test_returns_none_when_idle(self):
+        """No active recording means nothing to rename."""
+        acr = ArrivalClipRecorder(make_clip_manager())
+        assert acr.rename_to_final() is None
+
+
+class TestGetTempPath:
+    """Tests for get_temp_path delegation."""
+
+    def test_delegates_to_inner_recorder(self):
+        """An active recording exposes the inner recorder's temp path."""
+        acr = ArrivalClipRecorder(make_clip_manager())
+        inner = Mock()
+        inner.get_temp_path.return_value = Path("/fake/arrival.mp4.tmp")
+        acr._recorder = inner
+
+        assert acr.get_temp_path() == Path("/fake/arrival.mp4.tmp")
+        inner.get_temp_path.assert_called_once()
+
+    def test_returns_none_when_idle(self):
+        """No active recording means no temp file."""
+        acr = ArrivalClipRecorder(make_clip_manager())
+        assert acr.get_temp_path() is None

--- a/tests/test_buffer_clip_manager.py
+++ b/tests/test_buffer_clip_manager.py
@@ -1,9 +1,29 @@
 """Tests for buffer clip manager module."""
 
+from datetime import datetime, timedelta
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, Mock, patch
 
 from kanyo.detection.buffer_clip_manager import BufferClipManager
+from kanyo.utils.visit_recorder import VisitRecorder
+
+
+def make_manager(tmp_path, **kwargs):
+    """Create a manager with mocked dependencies and a mocked executor.
+
+    The real ThreadPoolExecutor is shut down and replaced with a MagicMock so
+    tests can assert on scheduled work without spawning threads.
+    """
+    manager = BufferClipManager(
+        frame_buffer=MagicMock(),
+        visit_recorder=MagicMock(),
+        full_config={"timezone": "UTC"},
+        clips_dir=str(tmp_path / "clips"),
+        **kwargs,
+    )
+    manager._executor.shutdown(wait=True)
+    manager._executor = MagicMock()
+    return manager
 
 
 class TestBufferClipManagerInit:
@@ -66,6 +86,26 @@ class TestBufferClipManagerShutdown:
 
         assert manager._shutdown is False
         manager.shutdown()
+        assert manager._shutdown is True
+
+    def test_shutdown_is_idempotent(self):
+        """A second shutdown call returns early without touching the executor again."""
+        mock_buffer = MagicMock()
+        mock_recorder = MagicMock()
+
+        manager = BufferClipManager(
+            frame_buffer=mock_buffer,
+            visit_recorder=mock_recorder,
+            full_config={"timezone": "UTC"},
+        )
+
+        manager.shutdown()
+        executor_spy = MagicMock()
+        manager._executor = executor_spy
+
+        manager.shutdown()  # Second call must be a no-op
+
+        executor_spy.shutdown.assert_not_called()
         assert manager._shutdown is True
 
 
@@ -150,3 +190,440 @@ class TestBufferClipManagerIntegration:
         # This verifies the manager is set up correctly
         assert manager.visit_recorder == mock_recorder
         assert manager.frame_buffer == mock_buffer
+
+
+class TestCreateArrivalClip:
+    """Tests for create_arrival_clip scheduling from a visit recording."""
+
+    def test_no_visit_file_returns_false(self, tmp_path):
+        """Missing visit_file in metadata means no clip can be scheduled."""
+        manager = make_manager(tmp_path)
+
+        assert manager.create_arrival_clip({}) is False
+        manager._executor.submit.assert_not_called()
+
+    def test_nonexistent_visit_file_returns_false(self, tmp_path):
+        """A visit_file path that doesn't exist on disk is rejected."""
+        manager = make_manager(tmp_path)
+
+        metadata = {"visit_file": str(tmp_path / "missing.mp4")}
+        assert manager.create_arrival_clip(metadata) is False
+        manager._executor.submit.assert_not_called()
+
+    def test_missing_visit_start_returns_false(self, tmp_path):
+        """Without visit_start there is no timestamp to name the clip after."""
+        manager = make_manager(tmp_path)
+        visit_file = tmp_path / "visit.mp4"
+        visit_file.write_text("video")
+
+        metadata = {"visit_file": str(visit_file)}
+        assert manager.create_arrival_clip(metadata) is False
+        manager._executor.submit.assert_not_called()
+
+    def test_schedules_extraction_from_recording_start(self, tmp_path):
+        """Arrival clip is the first (before + after) seconds of the recording."""
+        manager = make_manager(tmp_path, clip_arrival_before=15, clip_arrival_after=30)
+        visit_file = tmp_path / "visit.mp4"
+        visit_file.write_text("video")
+
+        metadata = {
+            "visit_file": str(visit_file),
+            "visit_start": datetime(2026, 1, 3, 10, 30, 0),
+        }
+
+        assert manager.create_arrival_clip(metadata) is True
+
+        args = manager._executor.submit.call_args[0]
+        assert args[0] == manager._extract_clip_from_visit
+        assert args[1] == visit_file
+        assert args[2] == 0  # Starts at beginning (includes lead-in)
+        assert args[3] == 45  # before + after
+        assert args[4].name.endswith("_arrival.mp4")
+        assert args[5] == "arrival"
+
+    def test_parses_iso_string_visit_start(self, tmp_path):
+        """visit_start given as ISO string is parsed before naming the clip."""
+        manager = make_manager(tmp_path)
+        visit_file = tmp_path / "visit.mp4"
+        visit_file.write_text("video")
+
+        metadata = {
+            "visit_file": str(visit_file),
+            "visit_start": "2026-01-03T10:30:00",
+        }
+
+        assert manager.create_arrival_clip(metadata) is True
+
+        clip_path = manager._executor.submit.call_args[0][4]
+        assert "falcon_103000_" in clip_path.name
+
+
+class TestCreateDepartureClip:
+    """Tests for create_departure_clip offset calculation and scheduling."""
+
+    @staticmethod
+    def base_metadata(tmp_path) -> dict:
+        visit_file = tmp_path / "visit.mp4"
+        visit_file.write_text("video")
+        return {
+            "visit_file": str(visit_file),
+            "visit_start": "2026-01-03T10:00:00",
+            "visit_end": "2026-01-03T10:10:00",
+            "recording_start": "2026-01-03T09:59:45",
+            "recording_duration_seconds": 700.0,
+        }
+
+    def test_no_visit_file_returns_false(self, tmp_path):
+        """Missing visit_file means no clip can be scheduled."""
+        manager = make_manager(tmp_path)
+
+        assert manager.create_departure_clip({}) is False
+        manager._executor.submit.assert_not_called()
+
+    def test_missing_visit_end_returns_false(self, tmp_path):
+        """Without visit_end there is no departure moment to center on."""
+        manager = make_manager(tmp_path)
+        metadata = self.base_metadata(tmp_path)
+        del metadata["visit_end"]
+
+        assert manager.create_departure_clip(metadata) is False
+
+    def test_missing_recording_duration_returns_false(self, tmp_path):
+        """Zero recording duration means there is nothing to extract from."""
+        manager = make_manager(tmp_path)
+        metadata = self.base_metadata(tmp_path)
+        metadata["recording_duration_seconds"] = 0
+
+        assert manager.create_departure_clip(metadata) is False
+
+    def test_frame_based_offset_preferred(self, tmp_path):
+        """Frame-accurate last_detection_offset_seconds wins over wall clock."""
+        manager = make_manager(tmp_path, clip_departure_before=30, clip_departure_after=15)
+        metadata = self.base_metadata(tmp_path)
+        metadata["last_detection_offset_seconds"] = 600.0
+
+        assert manager.create_departure_clip(metadata) is True
+
+        args = manager._executor.submit.call_args[0]
+        assert args[0] == manager._extract_clip_from_visit
+        assert args[2] == 570.0  # 600 - 30
+        assert args[3] == 45  # 30 + 15
+        assert args[4].name.endswith("_departure.mp4")
+        assert args[5] == "departure"
+
+    def test_wall_clock_fallback(self, tmp_path):
+        """Without a frame offset, lead-in + visit duration locates the departure."""
+        manager = make_manager(tmp_path, clip_departure_before=30, clip_departure_after=15)
+        metadata = self.base_metadata(tmp_path)
+
+        assert manager.create_departure_clip(metadata) is True
+
+        # lead-in 15s + visit 600s = offset 615s; start = 615 - 30
+        args = manager._executor.submit.call_args[0]
+        assert args[2] == 585.0
+        assert args[3] == 45
+
+    def test_recording_duration_fallback(self, tmp_path):
+        """With no timing data at all, offset is estimated as duration - exit timeout."""
+        manager = make_manager(tmp_path, clip_departure_before=30, clip_departure_after=15)
+        metadata = self.base_metadata(tmp_path)
+        del metadata["recording_start"]
+
+        assert manager.create_departure_clip(metadata) is True
+
+        # offset = max(0, 700 - 90) = 610; start = 610 - 30
+        args = manager._executor.submit.call_args[0]
+        assert args[2] == 580.0
+
+    def test_clip_trimmed_at_recording_end(self, tmp_path):
+        """A clip extending past the file end is trimmed to the available footage."""
+        manager = make_manager(tmp_path, clip_departure_before=30, clip_departure_after=15)
+        metadata = self.base_metadata(tmp_path)
+        metadata["recording_duration_seconds"] = 600.0
+        metadata["last_detection_offset_seconds"] = 590.0
+
+        assert manager.create_departure_clip(metadata) is True
+
+        # start = 560; 560 + 45 > 600, so duration trims to 40
+        args = manager._executor.submit.call_args[0]
+        assert args[2] == 560.0
+        assert args[3] == 40.0
+
+    def test_too_short_trimmed_clip_skipped(self, tmp_path):
+        """A trimmed clip under 5 seconds is useless and gets skipped."""
+        manager = make_manager(tmp_path, clip_departure_before=30, clip_departure_after=15)
+        metadata = self.base_metadata(tmp_path)
+        metadata["recording_duration_seconds"] = 100.0
+        metadata["last_detection_offset_seconds"] = 128.0
+
+        # start = 98; only 2s of footage remain before file end
+        assert manager.create_departure_clip(metadata) is False
+        manager._executor.submit.assert_not_called()
+
+    def test_accepts_datetime_objects(self, tmp_path):
+        """Timestamps supplied as datetime objects need no ISO parsing."""
+        manager = make_manager(tmp_path)
+        metadata = self.base_metadata(tmp_path)
+        metadata["visit_start"] = datetime(2026, 1, 3, 10, 0, 0)
+        metadata["visit_end"] = datetime(2026, 1, 3, 10, 10, 0)
+        metadata["recording_start"] = datetime(2026, 1, 3, 9, 59, 45)
+
+        assert manager.create_departure_clip(metadata) is True
+
+
+class TestCreateClipFromBuffer:
+    """Tests for direct-from-buffer clip scheduling."""
+
+    def test_schedules_extraction_around_event(self, tmp_path):
+        """Clip spans before_seconds..after_seconds around the event time."""
+        manager = make_manager(tmp_path)
+        event_time = datetime(2026, 1, 3, 10, 30, 0)
+
+        result = manager.create_clip_from_buffer(
+            event_time=event_time,
+            event_name="perch",
+            before_seconds=10,
+            after_seconds=20,
+        )
+
+        assert result is True
+        args = manager._executor.submit.call_args[0]
+        assert args[0] == manager._extract_clip_from_buffer
+        assert args[1] == event_time - timedelta(seconds=10)
+        assert args[2] == event_time + timedelta(seconds=20)
+        assert args[3].name.endswith("_perch.mp4")
+        assert args[4] == "perch"
+
+
+class TestExtractCandidateClip:
+    """Tests for the departure-candidate snapshot mechanism (022-C)."""
+
+    def test_returns_future_for_explicit_path(self, tmp_path):
+        """Caller-supplied path is used verbatim and the future is handed back."""
+        manager = make_manager(tmp_path)
+        start = datetime(2026, 1, 3, 10, 30, 0)
+        end = datetime(2026, 1, 3, 10, 31, 0)
+        clip_path = tmp_path / "candidate.mp4.tmp"
+
+        future = manager.extract_candidate_clip(start, end, clip_path)
+
+        assert future is manager._executor.submit.return_value
+        args = manager._executor.submit.call_args[0]
+        assert args[0] == manager._extract_clip_from_buffer
+        assert args[1] == start
+        assert args[2] == end
+        assert args[3] == clip_path
+        assert args[4] == "departure-candidate"
+
+
+class TestExtractClipFromBuffer:
+    """Tests for the buffer extraction worker (called directly, no executor)."""
+
+    def test_success_returns_path(self, tmp_path):
+        """Successful buffer extraction returns the written path string."""
+        manager = make_manager(tmp_path, clip_fps=24, clip_crf=20)
+        manager.frame_buffer.extract_clip.return_value = True
+        start = datetime(2026, 1, 3, 10, 30, 0)
+        end = datetime(2026, 1, 3, 10, 31, 0)
+        clip_path = tmp_path / "clip.mp4"
+
+        result = manager._extract_clip_from_buffer(start, end, clip_path, "arrival")
+
+        assert result == str(clip_path)
+        manager.frame_buffer.extract_clip.assert_called_once_with(
+            start_time=start,
+            end_time=end,
+            output_path=clip_path,
+            fps=24,
+            crf=20,
+        )
+
+    def test_failure_returns_none(self, tmp_path):
+        """A failed buffer extraction returns None."""
+        manager = make_manager(tmp_path)
+        manager.frame_buffer.extract_clip.return_value = False
+
+        result = manager._extract_clip_from_buffer(
+            datetime(2026, 1, 3, 10, 30, 0),
+            datetime(2026, 1, 3, 10, 31, 0),
+            tmp_path / "clip.mp4",
+            "arrival",
+        )
+
+        assert result is None
+
+    def test_exception_returns_none(self, tmp_path):
+        """An exception inside extraction is swallowed and reported as None."""
+        manager = make_manager(tmp_path)
+        manager.frame_buffer.extract_clip.side_effect = RuntimeError("buffer gone")
+
+        result = manager._extract_clip_from_buffer(
+            datetime(2026, 1, 3, 10, 30, 0),
+            datetime(2026, 1, 3, 10, 31, 0),
+            tmp_path / "clip.mp4",
+            "arrival",
+        )
+
+        assert result is None
+
+
+class TestExtractClipFromVisit:
+    """Tests for the visit-file extraction worker (called directly, no executor)."""
+
+    def test_success_returns_path(self, tmp_path):
+        """Successful visit-file extraction returns the written path string."""
+        manager = make_manager(tmp_path)
+        visit_file = tmp_path / "visit.mp4"
+        clip_path = tmp_path / "clip.mp4"
+
+        with patch.object(
+            VisitRecorder, "extract_clip_from_file", return_value=True
+        ) as mock_extract:
+            result = manager._extract_clip_from_visit(visit_file, 10.0, 45.0, clip_path, "arrival")
+
+        assert result == str(clip_path)
+        mock_extract.assert_called_once_with(
+            visit_file=visit_file,
+            start_offset=10.0,
+            duration=45.0,
+            output_path=clip_path,
+        )
+
+    def test_failure_returns_none(self, tmp_path):
+        """A failed ffmpeg extraction returns None."""
+        manager = make_manager(tmp_path)
+
+        with patch.object(VisitRecorder, "extract_clip_from_file", return_value=False):
+            result = manager._extract_clip_from_visit(
+                tmp_path / "visit.mp4", 10.0, 45.0, tmp_path / "clip.mp4", "departure"
+            )
+
+        assert result is None
+
+    def test_exception_returns_none(self, tmp_path):
+        """An exception during extraction is swallowed and reported as None."""
+        manager = make_manager(tmp_path)
+
+        with patch.object(
+            VisitRecorder, "extract_clip_from_file", side_effect=OSError("disk full")
+        ):
+            result = manager._extract_clip_from_visit(
+                tmp_path / "visit.mp4", 10.0, 45.0, tmp_path / "clip.mp4", "departure"
+            )
+
+        assert result is None
+
+
+class TestCreateStandaloneArrivalClip:
+    """Tests for standalone arrival clip recording (mocked ffmpeg)."""
+
+    ARRIVAL = datetime(2026, 1, 3, 10, 30, 0)
+
+    def _create(self, tmp_path, mock_popen, encoder, lead_in_frames=None):
+        """Run create_standalone_arrival_clip with a forced encoder and mocked Popen."""
+        manager = make_manager(tmp_path)
+        with patch("kanyo.utils.visit_recorder.detect_hardware_encoder", return_value=encoder):
+            clip_path, recorder = manager.create_standalone_arrival_clip(
+                arrival_time=self.ARRIVAL,
+                lead_in_frames=lead_in_frames or [],
+                frame_size=(640, 480),
+            )
+        return clip_path, recorder, mock_popen
+
+    @staticmethod
+    def _close_stderr(recorder):
+        """Close the real stderr log handle opened by the method."""
+        if recorder is not None and recorder._stderr_file:
+            recorder._stderr_file.close()
+            recorder._stderr_file = None
+
+    @patch("kanyo.detection.buffer_clip_manager.subprocess.Popen")
+    def test_returns_tmp_path_and_initialized_recorder(self, mock_popen, tmp_path):
+        """Success returns a .mp4.tmp path and a recorder primed with arrival state."""
+        clip_path, recorder, _ = self._create(tmp_path, mock_popen, "libx264")
+
+        assert clip_path is not None
+        assert clip_path.name.endswith(".mp4.tmp")
+        assert recorder._visit_path == clip_path
+        assert recorder._final_path.name.endswith("_arrival.mp4")
+        assert recorder._visit_start == self.ARRIVAL
+        assert recorder._frame_size == (640, 480)
+        assert recorder._events == [
+            {
+                "type": "arrival",
+                "offset_seconds": 0,
+                "timestamp": self.ARRIVAL.isoformat(),
+            }
+        ]
+        assert recorder._process is mock_popen.return_value
+        self._close_stderr(recorder)
+
+    @patch("kanyo.detection.buffer_clip_manager.subprocess.Popen")
+    def test_videotoolbox_encoder_command(self, mock_popen, tmp_path):
+        """VideoToolbox branch maps CRF to its quality scale."""
+        clip_path, recorder, _ = self._create(tmp_path, mock_popen, "h264_videotoolbox")
+
+        cmd = mock_popen.call_args[0][0]
+        assert "h264_videotoolbox" in cmd
+        # Default CRF 23 -> quality (51 - 23) * 2 = 56
+        assert cmd[cmd.index("-q:v") + 1] == "56"
+        assert cmd[-1] == str(clip_path)
+        self._close_stderr(recorder)
+
+    @patch("kanyo.detection.buffer_clip_manager.subprocess.Popen")
+    def test_vaapi_encoder_command(self, mock_popen, tmp_path):
+        """VAAPI branch adds the device and hwupload filter."""
+        clip_path, recorder, _ = self._create(tmp_path, mock_popen, "h264_vaapi")
+
+        cmd = mock_popen.call_args[0][0]
+        assert "h264_vaapi" in cmd
+        assert "-vaapi_device" in cmd
+        assert cmd[cmd.index("-qp") + 1] == "23"
+        self._close_stderr(recorder)
+
+    @patch("kanyo.detection.buffer_clip_manager.subprocess.Popen")
+    def test_nvenc_encoder_command(self, mock_popen, tmp_path):
+        """NVENC branch uses constant-quality mode."""
+        clip_path, recorder, _ = self._create(tmp_path, mock_popen, "h264_nvenc")
+
+        cmd = mock_popen.call_args[0][0]
+        assert "h264_nvenc" in cmd
+        assert cmd[cmd.index("-cq") + 1] == "23"
+        self._close_stderr(recorder)
+
+    @patch("kanyo.detection.buffer_clip_manager.subprocess.Popen")
+    def test_software_encoder_command(self, mock_popen, tmp_path):
+        """libx264 fallback uses CRF directly."""
+        clip_path, recorder, _ = self._create(tmp_path, mock_popen, "libx264")
+
+        cmd = mock_popen.call_args[0][0]
+        assert "libx264" in cmd
+        assert cmd[cmd.index("-crf") + 1] == "23"
+        self._close_stderr(recorder)
+
+    @patch("kanyo.detection.buffer_clip_manager.subprocess.Popen")
+    def test_popen_failure_returns_none_pair(self, mock_popen, tmp_path):
+        """If ffmpeg can't start, the caller gets (None, None) and no recorder."""
+        mock_popen.side_effect = OSError("ffmpeg not found")
+
+        clip_path, recorder, _ = self._create(tmp_path, mock_popen, "libx264")
+
+        assert clip_path is None
+        assert recorder is None
+
+    @patch.object(VisitRecorder, "_write_raw_frame")
+    @patch("kanyo.detection.buffer_clip_manager.subprocess.Popen")
+    def test_lead_in_frames_are_written(self, mock_popen, mock_write, tmp_path):
+        """Buffered lead-in frames are decoded and piped to the recorder."""
+        decoded = object()
+        buffered_frame = Mock()
+        buffered_frame.decode.return_value = decoded
+
+        clip_path, recorder, _ = self._create(
+            tmp_path, mock_popen, "libx264", lead_in_frames=[buffered_frame, buffered_frame]
+        )
+
+        assert mock_write.call_count == 2
+        mock_write.assert_called_with(decoded)
+        assert buffered_frame.decode.call_count == 2
+        self._close_stderr(recorder)

--- a/tests/test_buffer_monitor.py
+++ b/tests/test_buffer_monitor.py
@@ -1,0 +1,688 @@
+"""Behavior tests for the buffer-based monitor (BufferMonitor).
+
+Covers the orchestration surfaces the 021-D regression file does not touch:
+frame-processing side branches, departure-candidate lifecycle (022-C),
+startup/arrival cancellation cleanup, roosting-stop departures with
+string-typed metadata timestamps, the run() loop (init phase, frame-skip
+path, outage sentinels, shutdown), and the main() CLI entry.
+
+Nothing real runs: capture is a scripted fake, the detector and recorders
+are mocks, the module clock is a controllable FakeTime, and the hardware
+encoder cache is pre-seeded so no ffmpeg probe fires.
+"""
+
+import signal
+from concurrent.futures import Future
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+import kanyo.detection.buffer_monitor as bm
+import kanyo.utils.encoder as encoder
+from kanyo.detection.event_types import FalconEvent
+from kanyo.detection.falcon_state import FalconState
+
+BASE = datetime(2026, 1, 1, 12, 0, 0)
+
+FRAME = np.zeros((4, 4, 3), dtype=np.uint8)
+
+
+class IsoTimestamp(str):
+    """ISO-8601 string that also answers strftime.
+
+    The state-machine metadata contract allows string timestamps
+    (buffer_monitor parses them defensively); FalconVisit id generation
+    needs strftime, so this models a str-typed timestamp faithfully.
+    """
+
+    def strftime(self, fmt: str) -> str:
+        return datetime.fromisoformat(self).strftime(fmt)
+
+
+class _Det:
+    """Minimal detection: only .confidence is inspected by the monitor."""
+
+    def __init__(self, confidence: float = 0.9):
+        self.confidence = confidence
+
+
+class FakeTime:
+    """Controllable stand-in for the module's ``time`` import."""
+
+    def __init__(self, start: float = 1000.0):
+        self.now = start
+
+    def time(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.now += seconds
+
+
+class FakeCapture:
+    """Scripted stand-in for StreamCapture: frames() is a test generator."""
+
+    def __init__(self, gen_factory):
+        self._gen_factory = gen_factory
+        self.disconnected = False
+        self.on_connection_issue = None
+
+    def frames(self, skip=0):
+        return self._gen_factory()
+
+    def disconnect(self):
+        self.disconnected = True
+
+
+def _frame(number: int, timestamp: datetime) -> SimpleNamespace:
+    return SimpleNamespace(data=FRAME, frame_number=number, timestamp=timestamp)
+
+
+def _mock_visit_recorder(recording: bool = False) -> MagicMock:
+    vr = MagicMock()
+    vr.is_recording = recording
+    vr.stream_outage_exceeded = False
+    vr.lead_in_seconds = 15
+    vr.get_temp_path.return_value = None
+    vr.stop_recording.return_value = (None, {})
+    return vr
+
+
+def _mock_arrival_recorder(recording: bool = False) -> MagicMock:
+    ar = MagicMock()
+    ar.is_recording.return_value = recording
+    ar.get_temp_path.return_value = None
+    return ar
+
+
+def _raising_path(name: str = "stuck.tmp") -> MagicMock:
+    """A Path-like whose unlink always fails with OSError."""
+    p = MagicMock()
+    p.exists.return_value = True
+    p.unlink.side_effect = OSError("permission denied")
+    p.name = name
+    return p
+
+
+def make_monitor(tmp_path, **kwargs) -> bm.BufferMonitor:
+    """Construct a BufferMonitor and replace heavy collaborators with mocks."""
+    kwargs.setdefault("presence_enabled", False)
+    kwargs.setdefault("clips_dir", str(tmp_path / "clips"))
+    kwargs.setdefault("full_config", {})
+    monitor = bm.BufferMonitor(stream_url="test://stream", **kwargs)
+
+    # Real clip manager holds a ThreadPoolExecutor — shut it down and mock.
+    monitor.clip_manager.shutdown()
+    monitor.clip_manager = MagicMock()
+    monitor.clip_manager.clip_departure_before = 30
+    monitor.clip_manager.clip_departure_after = 15
+
+    monitor.detector = MagicMock()
+    monitor.detector.detect_birds.return_value = []
+    monitor.detector.detect_with_raw.return_value = ([], [])
+
+    monitor.visit_recorder = _mock_visit_recorder()
+    monitor.arrival_clip_recorder = _mock_arrival_recorder()
+
+    monitor.event_handler = MagicMock()
+    monitor.event_handler.notifications = None
+    monitor.event_store = MagicMock()
+    return monitor
+
+
+@pytest.fixture(autouse=True)
+def _no_ffmpeg_probe(monkeypatch):
+    """Pre-seed the hardware-encoder cache so nothing probes ffmpeg."""
+    monkeypatch.setattr(encoder, "_detected_encoder", "libx264", raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _clean_shutdown_flag(monkeypatch):
+    """Keep the module-global SIGTERM flag isolated per test."""
+    monkeypatch.setattr(bm, "_shutdown_requested", False)
+
+
+class TestSigtermHandler:
+    def test_sigterm_sets_shutdown_flag(self):
+        assert bm._shutdown_requested is False
+        bm._handle_sigterm(signal.SIGTERM, None)
+        assert bm._shutdown_requested is True
+
+
+class TestProcessFrameBranches:
+    def test_active_arrival_clip_receives_every_processed_frame(self, tmp_path):
+        """While the arrival clip records, each processed frame is written to it."""
+        monitor = make_monitor(tmp_path)
+        monitor.state_machine = MagicMock()
+        monitor.state_machine.update.return_value = []
+        monitor.arrival_clip_recorder.is_recording.return_value = True
+
+        monitor.process_frame(FRAME, 1, BASE)
+
+        monitor.arrival_clip_recorder.write_frame.assert_called_once_with(FRAME, BASE)
+
+    def test_roosting_stop_mode_skips_yolo_within_interval(self, tmp_path):
+        """In roosting stop mode, YOLO polls run only every roosting_detection_interval."""
+        monitor = make_monitor(tmp_path)
+        monitor.roosting_mode_active = True
+        monitor.roosting_recording_mode = "stop"
+        monitor.roosting_detection_interval = 30
+        monitor.last_roosting_check = BASE
+
+        monitor.process_frame(FRAME, 1, BASE + timedelta(seconds=5))
+
+        monitor.detector.detect_birds.assert_not_called()
+        # The reduced-interval clock did not advance on a skipped poll
+        assert monitor.last_roosting_check == BASE
+
+    def test_detection_marks_visit_recorder_while_recording(self, tmp_path):
+        """A detected frame during an active recording marks the detection offset."""
+        monitor = make_monitor(tmp_path)
+        monitor.state_machine = MagicMock()
+        monitor.state_machine.update.return_value = []
+        monitor.visit_recorder.is_recording = True
+        monitor.detector.detect_birds.return_value = [_Det(0.8)]
+
+        monitor.process_frame(FRAME, 1, BASE)
+
+        monitor.visit_recorder.mark_detection.assert_called_once()
+        assert monitor.last_detection_time == BASE
+
+    def test_processing_error_is_swallowed_and_logged(self, tmp_path):
+        """A failure inside frame processing never propagates to the run loop."""
+        monitor = make_monitor(tmp_path)
+        monitor.frame_buffer = MagicMock()
+        monitor.frame_buffer.add_frame.side_effect = RuntimeError("boom")
+
+        monitor.process_frame(FRAME, 1, BASE)  # must not raise
+
+        monitor.detector.detect_birds.assert_not_called()
+
+    def test_startup_cancelled_when_ratio_below_threshold(self, tmp_path):
+        """A failed startup confirmation resets state and deletes .tmp recordings."""
+        monitor = make_monitor(
+            tmp_path,
+            full_config={
+                "arrival_confirmation_seconds": 5,
+                "arrival_confirmation_ratio": 0.5,
+            },
+        )
+        monitor.state_machine = MagicMock()
+        monitor.state_machine.update.return_value = []
+
+        arrival_tmp = tmp_path / "arrival.mp4.tmp"
+        arrival_tmp.write_bytes(b"x")
+        monitor.arrival_clip_recorder.get_temp_path.return_value = arrival_tmp
+        visit_tmp = _raising_path("visit.mp4.tmp")
+        monitor.visit_recorder.get_temp_path.return_value = visit_tmp
+
+        monitor.startup_pending = True
+        monitor.startup_pending_start = BASE
+        monitor.startup_detection_count = 0
+        monitor.startup_frame_count = 4
+
+        # Window elapsed, no detections in it: 0/5 < 0.5 → cancel
+        monitor.process_frame(FRAME, 1, BASE + timedelta(seconds=6))
+
+        assert monitor.startup_pending is False
+        assert monitor.startup_frame_count == 0
+        monitor.state_machine.reset_to_absent.assert_called_once()
+        # .tmp cleanup: the deletable file is gone, the stuck one only logged
+        assert not arrival_tmp.exists()
+        visit_tmp.unlink.assert_called_once()
+
+
+class TestDepartureCandidate:
+    def test_snapshot_without_last_detection_is_refused(self, tmp_path):
+        monitor = make_monitor(tmp_path)
+        monitor.state_machine = MagicMock()
+        monitor.state_machine.last_detection = None
+
+        monitor._snapshot_departure_candidate(BASE)
+
+        assert monitor._departure_candidate is None
+        monitor.clip_manager.extract_candidate_clip.assert_not_called()
+
+    def test_snapshot_discards_stale_candidate_first(self, tmp_path):
+        """A leftover candidate is discarded before a new one is snapshotted."""
+        monitor = make_monitor(tmp_path)
+        monitor.state_machine = MagicMock()
+        monitor.state_machine.last_detection = BASE
+
+        stale_future: Future = Future()
+        stale_future.set_result(None)
+        stale_tmp = MagicMock()
+        stale_tmp.exists.return_value = False
+        monitor._departure_candidate = (stale_future, stale_tmp, tmp_path / "old.mp4")
+
+        new_future: Future = Future()
+        monitor.clip_manager.extract_candidate_clip.return_value = new_future
+
+        monitor._snapshot_departure_candidate(BASE + timedelta(seconds=60))
+
+        assert monitor._departure_candidate is not None
+        assert monitor._departure_candidate[0] is new_future
+        monitor.clip_manager.extract_candidate_clip.assert_called_once()
+
+    def test_discard_tolerates_failed_extraction(self, tmp_path):
+        monitor = make_monitor(tmp_path)
+        failed: Future = Future()
+        failed.set_exception(RuntimeError("extraction died"))
+        tmp = MagicMock()
+        tmp.exists.return_value = False
+        monitor._departure_candidate = (failed, tmp, tmp_path / "final.mp4")
+
+        monitor._discard_departure_candidate()  # must not raise
+
+        assert monitor._departure_candidate is None
+        tmp.unlink.assert_not_called()
+
+    def test_discard_logs_when_tmp_cannot_be_deleted(self, tmp_path):
+        monitor = make_monitor(tmp_path)
+        done: Future = Future()
+        done.set_result("clip.mp4")
+        tmp = _raising_path("cand.mp4.tmp")
+        monitor._departure_candidate = (done, tmp, tmp_path / "final.mp4")
+
+        monitor._discard_departure_candidate()  # OSError swallowed with warning
+
+        assert monitor._departure_candidate is None
+        tmp.unlink.assert_called_once()
+
+    def test_discard_deletes_existing_tmp_file(self, tmp_path):
+        monitor = make_monitor(tmp_path)
+        tmp = tmp_path / "cand.mp4.tmp"
+        tmp.write_bytes(b"video")
+        done: Future = Future()
+        done.set_result(str(tmp))
+        monitor._departure_candidate = (done, tmp, tmp_path / "final.mp4")
+
+        monitor._discard_departure_candidate()
+
+        assert monitor._departure_candidate is None
+        assert not tmp.exists()
+
+    def test_finalize_returns_false_when_extraction_failed(self, tmp_path):
+        monitor = make_monitor(tmp_path)
+        failed: Future = Future()
+        failed.set_exception(RuntimeError("extraction died"))
+        tmp = MagicMock()
+        tmp.exists.return_value = False
+        monitor._departure_candidate = (failed, tmp, tmp_path / "final.mp4")
+
+        assert monitor._finalize_departure_candidate(BASE) is False
+        assert monitor._departure_candidate is None
+
+    def test_finalize_returns_false_when_rename_fails(self, tmp_path):
+        monitor = make_monitor(tmp_path)
+        done: Future = Future()
+        done.set_result("clip.mp4")
+        tmp = MagicMock()
+        tmp.exists.return_value = True
+        tmp.rename.side_effect = OSError("cross-device link")
+        tmp.name = "cand.mp4.tmp"
+        monitor._departure_candidate = (done, tmp, tmp_path / "final.mp4")
+
+        assert monitor._finalize_departure_candidate(BASE) is False
+
+    def test_finalize_renames_candidate_to_final(self, tmp_path):
+        monitor = make_monitor(tmp_path)
+        tmp = tmp_path / "cand.mp4.tmp"
+        tmp.write_bytes(b"video")
+        final = tmp_path / "cand.mp4"
+        done: Future = Future()
+        done.set_result(str(tmp))
+        monitor._departure_candidate = (done, tmp, final)
+
+        assert monitor._finalize_departure_candidate(BASE) is True
+        assert final.exists()
+        assert not tmp.exists()
+
+
+class TestDepartedEvent:
+    def test_departure_during_pending_arrival_cancels_instead(self, tmp_path):
+        """DEPARTED while arrival is unconfirmed cancels the arrival, cleans .tmp files."""
+        monitor = make_monitor(tmp_path)
+        monitor.state_machine = MagicMock()
+        monitor.arrival_pending = True
+        monitor.arrival_pending_start = BASE
+        monitor.arrival_detection_count = 1
+        monitor.arrival_frame_count = 10
+
+        arrival_tmp = tmp_path / "arrival.mp4.tmp"
+        arrival_tmp.write_bytes(b"x")
+        monitor.arrival_clip_recorder.get_temp_path.return_value = arrival_tmp
+        visit_tmp = _raising_path("visit.mp4.tmp")
+        monitor.visit_recorder.get_temp_path.return_value = visit_tmp
+
+        monitor._handle_event(FalconEvent.DEPARTED, BASE + timedelta(seconds=8), {})
+
+        assert monitor.arrival_pending is False
+        monitor.state_machine.reset_to_absent.assert_called_once()
+        assert not arrival_tmp.exists()  # deletable .tmp removed
+        visit_tmp.unlink.assert_called_once()  # stuck .tmp only logged
+        # The departure was NOT surfaced as a real visit
+        monitor.event_store.append.assert_not_called()
+        monitor.event_handler.handle_event.assert_not_called()
+
+    def test_roosting_stop_departure_with_string_timestamps(self, tmp_path):
+        """A roosting-stop departure finalizes the candidate and records the visit,
+        parsing str-typed visit_start/visit_end metadata."""
+        monitor = make_monitor(tmp_path)
+        monitor.roosting_mode_active = True
+        monitor.roosting_recording_mode = "stop"
+        monitor._roosting_visit_metadata = {"visit_file": "roost.mp4"}
+        monitor._visit_peak_confidence = 0.77
+
+        cand_tmp = tmp_path / "cand.mp4.tmp"
+        cand_tmp.write_bytes(b"video")
+        cand_final = tmp_path / "cand.mp4"
+        done: Future = Future()
+        done.set_result(str(cand_tmp))
+        monitor._departure_candidate = (done, cand_tmp, cand_final)
+
+        metadata = {
+            "visit_start": IsoTimestamp("2026-01-01T10:00:00"),
+            "visit_end": IsoTimestamp("2026-01-01T11:00:00"),
+        }
+        monitor._frame_now = BASE
+        monitor._handle_event(FalconEvent.DEPARTED, BASE, metadata)
+
+        assert cand_final.exists()
+        assert monitor.roosting_mode_active is False
+        assert monitor._roosting_visit_metadata is None
+        row = monitor.event_store.append.call_args[0][0]
+        assert row.peak_confidence == 0.77
+        assert row.departure_clip_path is not None
+        monitor.event_handler.handle_event.assert_called_once()
+        assert monitor._visit_peak_confidence == 0.0  # reset for next visit
+
+    def test_normal_departure_parses_string_visit_start(self, tmp_path):
+        """A normal departure with str-typed visit_start still records a full row."""
+        monitor = make_monitor(tmp_path)
+        monitor.visit_recorder.is_recording = True
+        monitor.visit_recorder.stop_recording.return_value = (
+            "visit.mp4",
+            {"duration_seconds": 42.0},
+        )
+        monitor.clip_manager.create_departure_clip.return_value = True
+        monitor._visit_peak_confidence = 0.66
+
+        metadata = {
+            "visit_start": IsoTimestamp("2026-01-01T10:00:00"),
+            "visit_end": BASE,
+        }
+        monitor._frame_now = BASE
+        monitor._handle_event(FalconEvent.DEPARTED, BASE, metadata)
+
+        row = monitor.event_store.append.call_args[0][0]
+        assert row.peak_confidence == 0.66
+        assert row.departure_clip_path is not None
+        monitor.clip_manager.create_departure_clip.assert_called_once()
+
+
+class TestContinuationArrivalClip:
+    def test_discard_logs_when_file_cannot_be_deleted(self, tmp_path):
+        monitor = make_monitor(tmp_path)
+        monitor.arrival_pending_start = BASE
+        stuck = _raising_path("arrival.mp4.tmp")
+        monitor.arrival_clip_recorder.get_temp_path.return_value = stuck
+        monitor.arrival_clip_recorder.is_recording.return_value = False
+
+        monitor._discard_continuation_arrival_clip(BASE)  # OSError swallowed
+
+        stuck.unlink.assert_called_once()
+
+
+class TestStartupConfirmation:
+    def test_confirm_without_startup_notification(self, tmp_path):
+        """notify_on_startup=False confirms presence silently."""
+        monitor = make_monitor(tmp_path, notify_on_startup=False)
+        monitor.state_machine = MagicMock()
+        monitor.startup_pending = True
+        monitor.startup_pending_start = BASE
+        monitor.startup_detection_count = 3
+        monitor.startup_frame_count = 5
+
+        monitor._confirm_startup_presence(BASE + timedelta(seconds=10))
+
+        monitor.state_machine.confirm_startup_presence.assert_called_once()
+        monitor.event_handler.handle_event.assert_not_called()
+        assert monitor.startup_pending is False
+        assert monitor.startup_frame_count == 0
+
+
+class TestRunLoop:
+    def test_full_startup_cycle_to_roosting(self, tmp_path, monkeypatch):
+        """Init with a bird → PENDING_STARTUP with startup arrival clip →
+        confirmation → ROOSTING; heartbeat and max-runtime exit; clean shutdown."""
+        fake_time = FakeTime(1000.0)
+        monkeypatch.setattr(bm, "time", fake_time)
+
+        monitor = make_monitor(
+            tmp_path,
+            presence_enabled=True,
+            process_interval_frames=1,
+            record_arrival_on_startup=True,
+            max_runtime_seconds=500,
+            full_config={
+                "arrival_confirmation_seconds": 5,
+                "arrival_confirmation_ratio": 0.3,
+            },
+        )
+        monitor.presence = MagicMock()
+        monitor.presence.update.return_value = True
+        monitor.detector.detect_birds.return_value = [_Det(0.9)]
+        monitor.detector.detect_with_raw.return_value = ([_Det(0.9)], [_Det(0.9)])
+        monitor.visit_recorder.is_recording = True
+        monitor.visit_recorder.stop_recording.return_value = (
+            "visit.mp4",
+            {"duration_seconds": 9.0},
+        )
+        monitor.arrival_clip_recorder.is_recording.return_value = True
+
+        def gen():
+            # Three init frames (elapsed < 30s)
+            for i in range(3):
+                yield _frame(i, BASE + timedelta(seconds=i))
+            # Init window over: next frame completes initialization
+            fake_time.now = 1031.0
+            yield _frame(3, BASE + timedelta(seconds=31))
+            yield _frame(4, BASE + timedelta(seconds=33))
+            # Heartbeat due (>=300s since loop start), confirmation window over
+            fake_time.now = 1400.0
+            yield _frame(5, BASE + timedelta(seconds=38))
+            # Max runtime reached after this frame
+            fake_time.now = 1600.0
+            yield _frame(6, BASE + timedelta(seconds=40))
+
+        monitor.capture = FakeCapture(gen)
+        monitor.run()
+
+        # Startup presence confirmed: real state machine reached ROOSTING
+        assert monitor.state_machine.state == FalconState.ROOSTING
+        # Startup arrival clip was recorded (record_arrival_on_startup=True)
+        monitor.arrival_clip_recorder.start_recording.assert_called_once()
+        # Presence tracker was seeded from the init detections
+        monitor.presence.update.assert_called()
+        # Startup notification flowed through the filter to the handler
+        arrived_calls = [
+            c
+            for c in monitor.event_handler.handle_event.call_args_list
+            if c.args[0] == FalconEvent.ARRIVED
+        ]
+        assert len(arrived_calls) == 1
+        # Shutdown path: visit + arrival clip finalized, capture disconnected
+        monitor.visit_recorder.rename_to_final.assert_called()
+        monitor.arrival_clip_recorder.rename_to_final.assert_called()
+        monitor.clip_manager.shutdown.assert_called_once()
+        assert monitor.capture.disconnected is True
+
+    def test_startup_without_arrival_clip(self, tmp_path, monkeypatch):
+        """record_arrival_on_startup=False skips the startup arrival clip but
+        still starts the visit recording."""
+        fake_time = FakeTime(1000.0)
+        monkeypatch.setattr(bm, "time", fake_time)
+
+        monitor = make_monitor(
+            tmp_path,
+            process_interval_frames=1,
+            record_arrival_on_startup=False,
+        )
+        monitor.detector.detect_birds.return_value = [_Det(0.8)]
+
+        def gen():
+            yield _frame(0, BASE)
+            fake_time.now = 1031.0
+            yield _frame(1, BASE + timedelta(seconds=31))
+
+        monitor.capture = FakeCapture(gen)
+        monitor.run()
+
+        monitor.arrival_clip_recorder.start_recording.assert_not_called()
+        monitor.visit_recorder.start_recording.assert_called_once()
+        assert monitor.startup_pending is True
+        assert monitor.state_machine.state == FalconState.PENDING_STARTUP
+
+    def test_skip_path_outage_reset_and_keyboard_interrupt(self, tmp_path, monkeypatch):
+        """Skipped frames still feed the recorders; an exceeded outage on a
+        skipped frame resets state; Ctrl+C exits cleanly."""
+        fake_time = FakeTime(1000.0)
+        monkeypatch.setattr(bm, "time", fake_time)
+
+        monitor = make_monitor(tmp_path, process_interval_frames=3)
+        vr = monitor.visit_recorder
+        ar = monitor.arrival_clip_recorder
+
+        def gen():
+            # Empty init window: first frame completes init to ABSENT, then
+            # (counter=1) hits the skip path with an exceeded outage.
+            fake_time.now = 1031.0
+            vr.is_recording = True
+            vr.stream_outage_exceeded = True
+            yield _frame(1, BASE + timedelta(seconds=31))
+            # Next skipped frame feeds only the active arrival clip
+            vr.is_recording = False
+            ar.is_recording.return_value = True
+            yield _frame(2, BASE + timedelta(seconds=32))
+            # counter=3 → this frame is processed
+            ar.is_recording.return_value = False
+            yield _frame(3, BASE + timedelta(seconds=33))
+            raise KeyboardInterrupt
+
+        monitor.capture = FakeCapture(gen)
+        monitor.run()  # KeyboardInterrupt handled inside
+
+        # Outage-exceeded on the skip path stopped both recorders
+        vr.stop_recording.assert_called()
+        assert monitor.state_machine.state == FalconState.ABSENT
+        # The second skipped frame was written to the arrival clip
+        ar.write_frame.assert_called_once()
+        # The third frame went through detection
+        monitor.detector.detect_birds.assert_called_once()
+        assert monitor.capture.disconnected is True
+
+    def test_sigterm_breaks_run_loop(self, tmp_path, monkeypatch):
+        """The SIGTERM flag set by the handler breaks the loop before processing."""
+        fake_time = FakeTime(1000.0)
+        monkeypatch.setattr(bm, "time", fake_time)
+
+        monitor = make_monitor(tmp_path)
+        bm._handle_sigterm(signal.SIGTERM, None)
+        assert bm._shutdown_requested is True
+
+        def gen():
+            yield _frame(1, BASE)
+            raise AssertionError("loop must break before requesting a second frame")
+
+        monitor.capture = FakeCapture(gen)
+        monitor.run()
+
+        monitor.detector.detect_birds.assert_not_called()
+        assert monitor.capture.disconnected is True
+
+    def test_outage_during_init_is_dropped(self, tmp_path, monkeypatch):
+        """A no-frame sentinel during startup init clears without recovery logic."""
+        fake_time = FakeTime(1000.0)
+        monkeypatch.setattr(bm, "time", fake_time)
+
+        monitor = make_monitor(tmp_path)
+
+        def gen():
+            yield None  # sentinel: outage begins
+            yield _frame(1, BASE)  # first real frame, still initializing
+
+        monitor.capture = FakeCapture(gen)
+        monitor.run()
+
+        assert monitor._outage_start is None
+        assert monitor._outage_sentinel_count == 0
+        # No recovery confirmation was started
+        assert monitor.recovery_pending is False
+
+
+class TestMain:
+    @pytest.fixture
+    def main_env(self, monkeypatch):
+        cfg: dict = {}
+        load_config = MagicMock(return_value=cfg)
+        monkeypatch.setattr(bm, "load_config", load_config)
+        monkeypatch.setattr(bm, "setup_logging_from_config", MagicMock())
+        nm_instance = MagicMock()
+        monkeypatch.setattr(bm, "NotificationManager", MagicMock(return_value=nm_instance))
+        monitor = MagicMock()
+        monitor_cls = MagicMock(return_value=monitor)
+        monkeypatch.setattr(bm, "BufferMonitor", monitor_cls)
+        return SimpleNamespace(
+            cfg=cfg,
+            load_config=load_config,
+            monitor=monitor,
+            monitor_cls=monitor_cls,
+            nm=nm_instance,
+        )
+
+    def test_default_config_builds_and_runs_monitor(self, main_env, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["buffer_monitor.py"])
+
+        bm.main()
+
+        main_env.load_config.assert_called_once_with("config.yaml")
+        main_env.monitor.run.assert_called_once()
+        # The connection-issue alert closure routes to the admin alert channel
+        alert = main_env.monitor.capture.on_connection_issue
+        alert("stream down")
+        main_env.monitor.event_handler.notifications.send_system_alert.assert_called_once_with(
+            "stream down"
+        )
+
+    def test_harvard_flag_and_duration(self, main_env, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["buffer_monitor.py", "--harvard", "--duration", "2"])
+
+        bm.main()
+
+        main_env.load_config.assert_called_once_with("test_config_harvard.yaml")
+        assert main_env.cfg["max_runtime_seconds"] == 120
+        assert main_env.monitor_cls.call_args.kwargs["max_runtime_seconds"] == 120
+
+    def test_nsw_flag(self, main_env, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["buffer_monitor.py", "--nsw"])
+
+        bm.main()
+
+        main_env.load_config.assert_called_once_with("test_config_nsw.yaml")
+
+    def test_keyboard_interrupt_is_handled(self, main_env, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["buffer_monitor.py"])
+        main_env.monitor.run.side_effect = KeyboardInterrupt
+
+        bm.main()  # must not raise
+
+    def test_fatal_error_is_reraised(self, main_env, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["buffer_monitor.py"])
+        main_env.monitor.run.side_effect = RuntimeError("fatal")
+
+        with pytest.raises(RuntimeError, match="fatal"):
+            bm.main()

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -1,0 +1,264 @@
+"""Tests for StreamCapture connection, lifecycle, and property behavior.
+
+Complements test_stream_reader_thread.py (which owns the reader-thread /
+sentinel behavior) with the connect() error paths, the bounded-queue drain
+race, video properties, and the context-manager protocol. No network and no
+real captures: cv2.VideoCapture and time.sleep are patched throughout.
+"""
+
+import logging
+import queue
+import threading
+import time
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import cv2
+import numpy as np
+import pytest
+
+from kanyo.detection.capture import BACKOFF_MIN_SECONDS, Frame, StreamCapture
+
+# Non-YouTube URL: connect() uses it directly, no yt-dlp subprocess involved.
+STREAM_URL = "http://example.com/test-stream.mp4"
+
+
+def make_frame_data(value: int = 0) -> np.ndarray:
+    """A tiny distinguishable BGR frame."""
+    return np.full((4, 4, 3), value, dtype=np.uint8)
+
+
+class FakePropsCapture:
+    """Minimal cv2.VideoCapture stand-in exposing get() properties."""
+
+    def __init__(self, opened: bool = True, props: dict | None = None) -> None:
+        self._opened = opened
+        self._props = props or {}
+        self.released = False
+
+    def isOpened(self) -> bool:
+        return self._opened and not self.released
+
+    def read(self):
+        return False, None
+
+    def release(self) -> None:
+        self.released = True
+
+    def get(self, prop):
+        return self._props.get(prop, 0)
+
+
+class ScriptedCapture(FakePropsCapture):
+    """Returns each scripted ndarray once, then fails."""
+
+    def __init__(self, script: list) -> None:
+        super().__init__()
+        self._script = list(script)
+
+    def read(self):
+        if self._script:
+            return True, self._script.pop(0)
+        return False, None
+
+
+class StubbornCapture:
+    """A capture whose read() ignores release() — a wedged ffmpeg read.
+
+    The read only returns once ``allow_exit`` is set, letting the test
+    release the thread after asserting the join-timeout warning.
+    """
+
+    def __init__(self, allow_exit: threading.Event) -> None:
+        self._allow_exit = allow_exit
+        self.released = False
+
+    def isOpened(self) -> bool:
+        return True
+
+    def read(self):
+        while not self._allow_exit.is_set():
+            time.sleep(0.005)
+        return False, None
+
+    def release(self) -> None:
+        self.released = True
+
+
+class TestConnectErrorPaths:
+    """connect() failure handling beyond the yt-dlp RuntimeError path."""
+
+    def test_unexpected_exception_backs_off_and_returns_false(self):
+        """A non-RuntimeError from the capture layer (e.g. an OS error) is
+        caught, counted as a failure, and slept through — never raised."""
+        capture = StreamCapture(STREAM_URL)
+
+        with patch(
+            "kanyo.detection.capture.cv2.VideoCapture",
+            side_effect=OSError("device unavailable"),
+        ):
+            with patch("kanyo.detection.capture.time.sleep") as mock_sleep:
+                result = capture.connect()
+
+        assert result is False
+        assert capture._consecutive_failures == 1
+        mock_sleep.assert_called_once()
+        delay = mock_sleep.call_args[0][0]
+        assert delay >= BACKOFF_MIN_SECONDS
+
+    def test_use_tee_deprecation_warning(self, caplog):
+        """The deprecated use_tee flag is accepted but warns loudly."""
+        with caplog.at_level(logging.WARNING, logger="kanyo.detection.capture"):
+            StreamCapture(STREAM_URL, use_tee=True)
+
+        assert any("deprecated" in r.message for r in caplog.records)
+
+    def test_frames_raises_when_initial_connect_fails(self):
+        """frames() refuses to iterate when the first connect fails."""
+        capture = StreamCapture(STREAM_URL)
+
+        with patch.object(capture, "connect", return_value=False):
+            gen = capture.frames()
+            with pytest.raises(RuntimeError, match="Failed to connect"):
+                next(gen)
+
+
+class TestReadFrame:
+    """read_frame() guards and frame counting."""
+
+    def test_read_frame_without_capture_returns_none(self):
+        capture = StreamCapture(STREAM_URL)
+        assert capture._cap is None
+        assert capture.read_frame() is None
+
+    def test_frame_count_tracks_successful_reads(self):
+        capture = StreamCapture(STREAM_URL)
+        capture._cap = ScriptedCapture([make_frame_data(1), make_frame_data(2)])
+
+        assert capture.frame_count == 0
+        f1 = capture.read_frame()
+        f2 = capture.read_frame()
+        failed = capture.read_frame()
+
+        assert isinstance(f1, Frame) and isinstance(f2, Frame)
+        assert failed is None
+        assert capture.frame_count == 2  # failed read does not count
+
+
+class TestEnqueueDrainRace:
+    """_enqueue survives the full-then-empty race between put and drop."""
+
+    class RacyQueue:
+        """Queue stub: full on first put, empty on drain, then accepts."""
+
+        def __init__(self) -> None:
+            self.items: list = []
+            self._reject_next_put = True
+
+        def put_nowait(self, item) -> None:
+            if self._reject_next_put:
+                self._reject_next_put = False
+                raise queue.Full
+            self.items.append(item)
+
+        def get_nowait(self):
+            raise queue.Empty
+
+    def test_enqueue_retries_when_drain_finds_queue_empty(self):
+        """queue.Full followed by queue.Empty on the drop (consumer drained
+        the queue in between) still lands the item on the retry."""
+        capture = StreamCapture(STREAM_URL)
+        racy = self.RacyQueue()
+        capture._frame_queue = racy  # type: ignore[assignment]
+
+        frame = Frame(
+            data=make_frame_data(1),
+            frame_number=1,
+            width=4,
+            height=4,
+            timestamp=datetime.now(timezone.utc),
+        )
+        capture._enqueue(frame)
+
+        assert racy.items == [frame]
+
+
+class TestReaderThreadLifecycleEdges:
+    """Reader-thread start/stop edges not owned by test_stream_reader_thread."""
+
+    def test_start_reader_is_noop_while_thread_alive(self):
+        """A second _start_reader() while the reader runs must not spawn a
+        replacement thread (which would race on the shared queue)."""
+        allow_exit = threading.Event()
+        fake = StubbornCapture(allow_exit)
+        capture = StreamCapture(STREAM_URL)
+
+        try:
+            with patch("kanyo.detection.capture.cv2.VideoCapture", return_value=fake):
+                assert capture.connect() is True
+            capture._start_reader()
+            first_thread = capture._reader_thread
+            capture._start_reader()
+            assert capture._reader_thread is first_thread
+        finally:
+            allow_exit.set()
+            capture.disconnect()
+
+    def test_disconnect_warns_when_reader_ignores_join_timeout(self, caplog):
+        """A reader wedged in cap.read() past the join timeout is logged
+        loudly; disconnect() still returns instead of hanging."""
+        allow_exit = threading.Event()
+        fake = StubbornCapture(allow_exit)
+        capture = StreamCapture(STREAM_URL)
+
+        with patch("kanyo.detection.capture.cv2.VideoCapture", return_value=fake):
+            assert capture.connect() is True
+        capture._start_reader()
+        thread = capture._reader_thread
+        assert thread is not None and thread.is_alive()
+
+        try:
+            with patch("kanyo.detection.capture.READER_JOIN_TIMEOUT_S", 0.05):
+                with caplog.at_level(logging.WARNING, logger="kanyo.detection.capture"):
+                    capture.disconnect()
+
+            assert any("did not stop" in r.message for r in caplog.records)
+            assert capture._reader_thread is None
+            assert thread.is_alive()  # genuinely wedged past the timeout
+        finally:
+            allow_exit.set()
+            thread.join(timeout=2.0)
+        assert not thread.is_alive()
+
+
+class TestVideoProperties:
+    """total_frames / fps come from the capture, with disconnected defaults."""
+
+    def test_properties_default_to_zero_when_disconnected(self):
+        capture = StreamCapture(STREAM_URL)
+        assert capture.total_frames == 0
+        assert capture.fps == 0.0
+
+    def test_properties_read_from_capture(self):
+        capture = StreamCapture(STREAM_URL)
+        capture._cap = FakePropsCapture(
+            props={cv2.CAP_PROP_FRAME_COUNT: 250.0, cv2.CAP_PROP_FPS: 30.0}
+        )
+        assert capture.total_frames == 250
+        assert capture.fps == 30.0
+
+
+class TestContextManager:
+    """with StreamCapture(...) connects on enter and disconnects on exit."""
+
+    def test_enter_connects_and_exit_disconnects(self):
+        fake = FakePropsCapture(opened=True)
+        capture = StreamCapture(STREAM_URL)
+
+        with patch("kanyo.detection.capture.cv2.VideoCapture", return_value=fake):
+            with capture as entered:
+                assert entered is capture
+                assert capture.is_connected is True
+
+        assert capture._cap is None
+        assert fake.released is True

--- a/tests/test_clips.py
+++ b/tests/test_clips.py
@@ -1,5 +1,7 @@
 """Tests for clips module."""
 
+import io
+import subprocess
 from datetime import datetime
 from unittest.mock import patch
 
@@ -304,3 +306,419 @@ class TestThumbnailFilenames:
         )
 
         assert spec.thumbnail_filename_for("exit") == "2025-12-17_10-30-00_exit.jpg"
+
+
+class _FakeFFmpegProcess:
+    """Stand-in for subprocess.Popen running ffmpeg with -progress pipe:1."""
+
+    def __init__(self, lines=(), returncode=0, stderr_text=""):
+        self.stdout = io.StringIO("".join(lines))
+        self.stderr = io.StringIO(stderr_text)
+        self.returncode = returncode
+
+    def poll(self):
+        return self.returncode
+
+
+def _make_extractor(tmp_path, **config_overrides):
+    """Build a ClipExtractor writing into tmp_path with a real (empty) video file."""
+    config = {
+        "clips_dir": str(tmp_path / "clips"),
+        "clip_merge_threshold": 180,
+        "clip_compress": True,
+        "clip_crf": 23,
+        "clip_fps": 30,
+        "clip_encoder": "libx264",
+        "thumbnail_entrance_offset": 5,
+        "thumbnail_exit_offset": -10,
+    }
+    config.update(config_overrides)
+    video_path = tmp_path / "test_video.mp4"
+    video_path.touch()
+    return ClipExtractor(
+        config=config,
+        video_path=video_path,
+        fps=60.0,
+        video_duration_secs=900.0,
+    )
+
+
+class TestExtractClips:
+    """Behavior of extract_clips: ffmpeg command construction and error handling."""
+
+    def test_no_events_logs_and_returns_empty(self, tmp_path):
+        """With no events, extract_clips returns [] without touching ffmpeg."""
+        extractor = _make_extractor(tmp_path)
+
+        with patch("kanyo.generation.clips.subprocess.Popen") as mock_popen:
+            result = extractor.extract_clips()
+
+        assert result == []
+        mock_popen.assert_not_called()
+
+    def test_compress_libx264_builds_crf_command(self, tmp_path):
+        """Software encoding uses CRF quality and returns the extracted clip path."""
+        extractor = _make_extractor(tmp_path)
+        extractor.add_event("enter", frame=7800, timestamp=datetime(2025, 12, 17, 10, 30, 0))
+
+        process = _FakeFFmpegProcess()
+        with (
+            patch("kanyo.generation.clips.subprocess.Popen", return_value=process) as mock_popen,
+            patch("kanyo.generation.clips.subprocess.run") as mock_run,
+        ):
+            result = extractor.extract_clips()
+
+        cmd = mock_popen.call_args[0][0]
+        assert cmd[0] == "ffmpeg"
+        assert "-crf" in cmd
+        assert cmd[cmd.index("-crf") + 1] == "23"
+        assert cmd[cmd.index("-c:v") + 1] == "libx264"
+        assert "-preset" in cmd
+        # Output fps applied via -r for non-VAAPI encoders
+        assert cmd[cmd.index("-r") + 1] == "30"
+        expected_path = extractor.clips_dir / "2025-12-17_10-30-00_enter.mp4"
+        assert result == [expected_path]
+        # A thumbnail is extracted for the successful clip
+        mock_run.assert_called_once()
+
+    def test_compress_videotoolbox_quality_opts(self, tmp_path):
+        """VideoToolbox maps CRF to -q:v on its 1-100 scale."""
+        extractor = _make_extractor(tmp_path, clip_encoder="h264_videotoolbox")
+        extractor.add_event("enter", frame=7800, timestamp=datetime.now())
+
+        with (
+            patch(
+                "kanyo.generation.clips.subprocess.Popen",
+                return_value=_FakeFFmpegProcess(),
+            ) as mock_popen,
+            patch("kanyo.generation.clips.subprocess.run"),
+        ):
+            extractor.extract_clips()
+
+        cmd = mock_popen.call_args[0][0]
+        assert cmd[cmd.index("-c:v") + 1] == "h264_videotoolbox"
+        # (51 - 23) * 2 = 56 on the VideoToolbox quality scale
+        assert cmd[cmd.index("-q:v") + 1] == "56"
+
+    def test_compress_vaapi_device_and_filter(self, tmp_path):
+        """VAAPI adds the render device input option and hwupload filter."""
+        extractor = _make_extractor(tmp_path, clip_encoder="h264_vaapi")
+        extractor.add_event("enter", frame=7800, timestamp=datetime.now())
+
+        with (
+            patch(
+                "kanyo.generation.clips.subprocess.Popen",
+                return_value=_FakeFFmpegProcess(),
+            ) as mock_popen,
+            patch("kanyo.generation.clips.subprocess.run"),
+        ):
+            extractor.extract_clips()
+
+        cmd = mock_popen.call_args[0][0]
+        assert cmd[cmd.index("-vaapi_device") + 1] == "/dev/dri/renderD128"
+        assert cmd[cmd.index("-vf") + 1] == "format=nv12,hwupload,fps=30"
+        assert "-qp" in cmd
+
+    def test_compress_nvenc_uses_cq(self, tmp_path):
+        """Non-special hardware encoders (NVENC/QSV/AMF) use -cq quality."""
+        extractor = _make_extractor(tmp_path, clip_encoder="h264_nvenc")
+        extractor.add_event("enter", frame=7800, timestamp=datetime.now())
+
+        with (
+            patch(
+                "kanyo.generation.clips.subprocess.Popen",
+                return_value=_FakeFFmpegProcess(),
+            ) as mock_popen,
+            patch("kanyo.generation.clips.subprocess.run"),
+        ):
+            extractor.extract_clips()
+
+        cmd = mock_popen.call_args[0][0]
+        assert cmd[cmd.index("-cq") + 1] == "23"
+
+    def test_auto_hardware_detection(self, tmp_path):
+        """encoder='auto' with hardware encoding on calls detect_hardware_encoder."""
+        extractor = _make_extractor(tmp_path, clip_encoder="auto", clip_hardware_encoding=True)
+        extractor.add_event("enter", frame=7800, timestamp=datetime.now())
+
+        with (
+            patch(
+                "kanyo.generation.clips.detect_hardware_encoder",
+                return_value="h264_videotoolbox",
+            ) as mock_detect,
+            patch(
+                "kanyo.generation.clips.subprocess.Popen",
+                return_value=_FakeFFmpegProcess(),
+            ) as mock_popen,
+            patch("kanyo.generation.clips.subprocess.run"),
+        ):
+            extractor.extract_clips()
+
+        mock_detect.assert_called_once()
+        cmd = mock_popen.call_args[0][0]
+        assert cmd[cmd.index("-c:v") + 1] == "h264_videotoolbox"
+
+    def test_software_fallback_when_hardware_disabled(self, tmp_path):
+        """clip_hardware_encoding=False forces libx264 without detection."""
+        extractor = _make_extractor(tmp_path, clip_encoder=None, clip_hardware_encoding=False)
+        extractor.add_event("enter", frame=7800, timestamp=datetime.now())
+
+        with (
+            patch("kanyo.generation.clips.detect_hardware_encoder") as mock_detect,
+            patch(
+                "kanyo.generation.clips.subprocess.Popen",
+                return_value=_FakeFFmpegProcess(),
+            ) as mock_popen,
+            patch("kanyo.generation.clips.subprocess.run"),
+        ):
+            extractor.extract_clips()
+
+        mock_detect.assert_not_called()
+        cmd = mock_popen.call_args[0][0]
+        assert cmd[cmd.index("-c:v") + 1] == "libx264"
+
+    def test_progress_output_parsed(self, tmp_path, capsys):
+        """ffmpeg -progress lines are parsed into a percentage; bad lines ignored."""
+        extractor = _make_extractor(tmp_path)
+        extractor.add_event("enter", frame=7800, timestamp=datetime.now())
+
+        # Enter clip is 45s (15 before + 30 after); 10s in = 22%
+        process = _FakeFFmpegProcess(
+            lines=[
+                "frame=100\n",
+                "out_time_ms=10000000\n",  # 10s, > 5s threshold -> printed
+                "out_time_ms=garbage\n",  # unparseable -> silently ignored
+                "out_time_ms=12000000\n",  # only +2s since last -> not printed
+            ]
+        )
+        with (
+            patch("kanyo.generation.clips.subprocess.Popen", return_value=process),
+            patch("kanyo.generation.clips.subprocess.run"),
+        ):
+            result = extractor.extract_clips()
+
+        assert len(result) == 1
+        out = capsys.readouterr().out
+        assert "Encoding: 22%" in out
+        assert "10s / 45s" in out
+
+    def test_ffmpeg_failure_skips_clip(self, tmp_path):
+        """Nonzero ffmpeg exit is logged; clip is skipped, no thumbnail attempted."""
+        extractor = _make_extractor(tmp_path)
+        extractor.add_event("enter", frame=7800, timestamp=datetime.now())
+
+        process = _FakeFFmpegProcess(returncode=1, stderr_text="encode blew up")
+        with (
+            patch("kanyo.generation.clips.subprocess.Popen", return_value=process),
+            patch("kanyo.generation.clips.subprocess.run") as mock_run,
+        ):
+            result = extractor.extract_clips()
+
+        assert result == []
+        mock_run.assert_not_called()
+
+    def test_ffmpeg_not_installed_aborts_loop(self, tmp_path):
+        """FileNotFoundError (no ffmpeg) stops extraction after the first attempt."""
+        extractor = _make_extractor(tmp_path)
+        now = datetime.now()
+        # Two events far apart -> two planned clips
+        extractor.add_event("enter", frame=7800, timestamp=now)  # 130s
+        extractor.add_event("exit", frame=32520, timestamp=now)  # 542s
+
+        with patch(
+            "kanyo.generation.clips.subprocess.Popen",
+            side_effect=FileNotFoundError("ffmpeg"),
+        ) as mock_popen:
+            result = extractor.extract_clips()
+
+        assert result == []
+        # Break after the first failure, not one attempt per clip
+        assert mock_popen.call_count == 1
+
+    def test_copy_mode_uses_stream_copy(self, tmp_path):
+        """clip_compress=False re-muxes with -c copy via subprocess.run."""
+        extractor = _make_extractor(tmp_path, clip_compress=False)
+        extractor.add_event("enter", frame=7800, timestamp=datetime(2025, 12, 17, 10, 30, 0))
+
+        with patch("kanyo.generation.clips.subprocess.run") as mock_run:
+            result = extractor.extract_clips()
+
+        # First call is the clip copy, second the thumbnail
+        assert mock_run.call_count == 2
+        clip_cmd = mock_run.call_args_list[0][0][0]
+        assert clip_cmd[clip_cmd.index("-c") + 1] == "copy"
+        assert "-avoid_negative_ts" in clip_cmd
+        expected_path = extractor.clips_dir / "2025-12-17_10-30-00_enter.mp4"
+        assert result == [expected_path]
+
+    def test_copy_mode_failure_returns_empty(self, tmp_path):
+        """CalledProcessError in copy mode is caught; clip not reported extracted."""
+        extractor = _make_extractor(tmp_path, clip_compress=False)
+        extractor.add_event("enter", frame=7800, timestamp=datetime.now())
+
+        with patch(
+            "kanyo.generation.clips.subprocess.run",
+            side_effect=subprocess.CalledProcessError(1, ["ffmpeg"], stderr="bad input"),
+        ):
+            result = extractor.extract_clips()
+
+        assert result == []
+
+    def test_output_directory_created(self, tmp_path):
+        """extract_clips creates the clips directory before writing."""
+        extractor = _make_extractor(tmp_path)
+        extractor.add_event("enter", frame=7800, timestamp=datetime.now())
+        assert not extractor.clips_dir.exists()
+
+        with (
+            patch(
+                "kanyo.generation.clips.subprocess.Popen",
+                return_value=_FakeFFmpegProcess(),
+            ),
+            patch("kanyo.generation.clips.subprocess.run"),
+        ):
+            extractor.extract_clips()
+
+        assert extractor.clips_dir.is_dir()
+
+
+class TestExtractThumbnail:
+    """Behavior of _extract_thumbnail across event types."""
+
+    @staticmethod
+    def _spec(event_type, first_time=130.0, last_time=None, start=115.0, end=160.0):
+        return ClipSpec(
+            start_secs=start,
+            end_secs=end,
+            event_type=event_type,
+            event_timestamp=datetime(2025, 12, 17, 10, 30, 0),
+            first_event_time_secs=first_time,
+            last_event_time_secs=last_time,
+        )
+
+    def test_enter_thumbnail_offset(self, tmp_path):
+        """Enter thumbnails are taken entrance_offset seconds after the event."""
+        extractor = _make_extractor(tmp_path)
+        extractor.clips_dir.mkdir(parents=True)
+        spec = self._spec("enter")
+
+        with patch("kanyo.generation.clips.subprocess.run") as mock_run:
+            thumbs = extractor._extract_thumbnail(spec)
+
+        cmd = mock_run.call_args[0][0]
+        # 130s event + 5s offset = 135s, within [115, 160]
+        assert cmd[cmd.index("-ss") + 1] == "135.0"
+        assert cmd[cmd.index("-vframes") + 1] == "1"
+        assert thumbs == [extractor.clips_dir / "2025-12-17_10-30-00_enter.jpg"]
+
+    def test_exit_thumbnail_offset(self, tmp_path):
+        """Exit thumbnails are taken exit_offset seconds before the event."""
+        extractor = _make_extractor(tmp_path)
+        extractor.clips_dir.mkdir(parents=True)
+        spec = self._spec("exit", first_time=542.0, start=512.0, end=557.0)
+
+        with patch("kanyo.generation.clips.subprocess.run") as mock_run:
+            thumbs = extractor._extract_thumbnail(spec)
+
+        cmd = mock_run.call_args[0][0]
+        # 542s event - 10s offset = 532s
+        assert cmd[cmd.index("-ss") + 1] == "532.0"
+        assert thumbs == [extractor.clips_dir / "2025-12-17_10-30-00_exit.jpg"]
+
+    def test_merged_produces_enter_and_exit_thumbnails(self, tmp_path):
+        """Merged clips yield two thumbnails: entrance and exit."""
+        extractor = _make_extractor(tmp_path)
+        extractor.clips_dir.mkdir(parents=True)
+        spec = self._spec("merged", first_time=130.0, last_time=190.0, end=220.0)
+
+        with patch("kanyo.generation.clips.subprocess.run") as mock_run:
+            thumbs = extractor._extract_thumbnail(spec)
+
+        assert mock_run.call_count == 2
+        enter_cmd = mock_run.call_args_list[0][0][0]
+        exit_cmd = mock_run.call_args_list[1][0][0]
+        assert enter_cmd[enter_cmd.index("-ss") + 1] == "135.0"  # 130 + 5
+        assert exit_cmd[exit_cmd.index("-ss") + 1] == "180.0"  # 190 - 10
+        assert thumbs == [
+            extractor.clips_dir / "2025-12-17_10-30-00_enter.jpg",
+            extractor.clips_dir / "2025-12-17_10-30-00_exit.jpg",
+        ]
+
+    def test_thumbnail_time_clamped_to_clip_bounds(self, tmp_path):
+        """Thumbnail time is clamped into [start, end] of the clip."""
+        extractor = _make_extractor(tmp_path)
+        extractor.clips_dir.mkdir(parents=True)
+        # Event at 158s + 5s offset = 163s, past the 160s clip end -> clamp to 160
+        spec = self._spec("enter", first_time=158.0)
+
+        with patch("kanyo.generation.clips.subprocess.run") as mock_run:
+            extractor._extract_thumbnail(spec)
+
+        cmd = mock_run.call_args[0][0]
+        assert cmd[cmd.index("-ss") + 1] == "160.0"
+
+    def test_dry_run_extracts_nothing(self, tmp_path):
+        """Dry run logs intent without invoking ffmpeg."""
+        extractor = _make_extractor(tmp_path)
+        spec = self._spec("merged", first_time=130.0, last_time=190.0, end=220.0)
+
+        with patch("kanyo.generation.clips.subprocess.run") as mock_run:
+            thumbs = extractor._extract_thumbnail(spec, dry_run=True)
+
+        assert thumbs == []
+        mock_run.assert_not_called()
+
+    def test_ffmpeg_failure_yields_no_thumbnail(self, tmp_path):
+        """A failing ffmpeg call is logged and the thumbnail skipped."""
+        extractor = _make_extractor(tmp_path)
+        extractor.clips_dir.mkdir(parents=True)
+        spec = self._spec("enter")
+
+        with patch(
+            "kanyo.generation.clips.subprocess.run",
+            side_effect=subprocess.CalledProcessError(1, ["ffmpeg"], stderr="no frame"),
+        ):
+            thumbs = extractor._extract_thumbnail(spec)
+
+        assert thumbs == []
+
+
+class TestExtractFromVisit:
+    """Behavior of the extract_from_visit convenience wrapper."""
+
+    def test_replaces_existing_events(self, tmp_path):
+        """extract_from_visit clears prior events and adds enter + exit."""
+        extractor = _make_extractor(tmp_path)
+        extractor.add_event("enter", frame=100, timestamp=datetime.now())
+
+        now = datetime.now()
+        result = extractor.extract_from_visit(
+            enter_frame=7800,
+            exit_frame=11400,
+            enter_timestamp=now,
+            exit_timestamp=now,
+            dry_run=True,
+        )
+
+        assert result == []
+        assert len(extractor.events) == 2
+        assert extractor.events[0].event_type == "enter"
+        assert extractor.events[0].frame == 7800
+        assert extractor.events[1].event_type == "exit"
+        assert extractor.events[1].frame == 11400
+
+    def test_close_visit_merges_into_single_clip(self, tmp_path):
+        """A short visit (within merge_threshold) plans one merged clip."""
+        extractor = _make_extractor(tmp_path)
+        now = datetime.now()
+        extractor.extract_from_visit(
+            enter_frame=7800,  # 130s
+            exit_frame=11400,  # 190s -> 60s gap, within 180s threshold
+            enter_timestamp=now,
+            exit_timestamp=now,
+            dry_run=True,
+        )
+
+        clips = extractor.plan_clips()
+        assert len(clips) == 1
+        assert clips[0].event_type == "merged"

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1,8 +1,23 @@
 """Tests for configuration validation rules."""
 
+import logging
+import os
+from datetime import timedelta, timezone
+from unittest.mock import patch
+from zoneinfo import ZoneInfo
+
 import pytest
 
-from kanyo.utils.config import _validate
+from kanyo.utils.config import (
+    DEFAULTS,
+    _apply_env_overrides,
+    _cast,
+    _load_env_file,
+    _parse_timezone,
+    _validate,
+    get_now_tz,
+    load_config,
+)
 
 
 class TestConfigValidation:
@@ -51,3 +66,370 @@ class TestConfigValidation:
         cfg = {"video_source": "https://youtube.com/test", "clip_arrival_before": -5}
         with pytest.raises(ValueError, match="non-negative"):
             _validate(cfg)
+
+    def test_missing_video_source_fails(self):
+        """Empty or absent required field (video_source) should fail."""
+        with pytest.raises(ValueError, match="Missing required config field: video_source"):
+            _validate({"video_source": ""})
+
+    def test_ir_confidence_must_be_numeric(self):
+        """detection_confidence_ir must be a number when provided."""
+        cfg = {"video_source": "https://youtube.com/test", "detection_confidence_ir": "low"}
+        with pytest.raises(ValueError, match="detection_confidence_ir must be a number"):
+            _validate(cfg)
+
+    def test_ir_confidence_range(self):
+        """detection_confidence_ir must be 0.0-1.0 when provided."""
+        cfg = {"video_source": "https://youtube.com/test", "detection_confidence_ir": 1.5}
+        with pytest.raises(ValueError, match="detection_confidence_ir must be between"):
+            _validate(cfg)
+
+    def test_valid_ir_confidence_passes(self):
+        """A valid detection_confidence_ir passes validation."""
+        cfg = {"video_source": "https://youtube.com/test", "detection_confidence_ir": 0.3}
+        _validate(cfg)  # Should not raise
+
+    def test_negative_departure_clip_timing_fails(self):
+        """Negative departure clip timing values should fail."""
+        cfg = {"video_source": "https://youtube.com/test", "clip_departure_after": -1}
+        with pytest.raises(ValueError, match="clip_departure_before and clip_departure_after"):
+            _validate(cfg)
+
+    def test_short_arrival_clip_window_warns_but_passes(self, caplog):
+        """Arrival clip windows under 10s warn but do not fail validation."""
+        cfg = {
+            "video_source": "https://youtube.com/test",
+            "clip_arrival_before": 2,
+            "clip_arrival_after": 3,
+        }
+        with caplog.at_level(logging.WARNING, logger="kanyo.utils.config"):
+            _validate(cfg)  # Should not raise
+        assert "Arrival clip duration (5s) is very short" in caplog.text
+
+    def test_short_departure_clip_window_warns_but_passes(self, caplog):
+        """Departure clip windows under 10s warn but do not fail validation."""
+        cfg = {
+            "video_source": "https://youtube.com/test",
+            "clip_departure_before": 4,
+            "clip_departure_after": 4,
+        }
+        with caplog.at_level(logging.WARNING, logger="kanyo.utils.config"):
+            _validate(cfg)  # Should not raise
+        assert "Departure clip duration (8s) is very short" in caplog.text
+
+    def test_stream_read_timeout_must_be_positive(self):
+        """stream_read_timeout_s of zero or below should fail."""
+        cfg = {"video_source": "https://youtube.com/test", "stream_read_timeout_s": 0}
+        with pytest.raises(ValueError, match="stream_read_timeout_s must be a positive"):
+            _validate(cfg)
+
+    def test_high_frame_interval_warns_but_passes(self, caplog):
+        """frame_interval above 60 warns about coarse detection but passes."""
+        cfg = {"video_source": "https://youtube.com/test", "frame_interval": 120}
+        with caplog.at_level(logging.WARNING, logger="kanyo.utils.config"):
+            _validate(cfg)  # Should not raise
+        assert "frame_interval (120) is very high" in caplog.text
+
+    def test_arrival_confirmation_seconds_must_be_positive(self):
+        cfg = {"video_source": "https://youtube.com/test", "arrival_confirmation_seconds": 0}
+        with pytest.raises(ValueError, match="arrival_confirmation_seconds must be positive"):
+            _validate(cfg)
+
+    def test_arrival_confirmation_ratio_range(self):
+        cfg = {"video_source": "https://youtube.com/test", "arrival_confirmation_ratio": 1.5}
+        with pytest.raises(ValueError, match="arrival_confirmation_ratio must be between"):
+            _validate(cfg)
+
+    def test_merge_window_must_be_non_negative(self):
+        cfg = {"video_source": "https://youtube.com/test", "merge_window_seconds": -1}
+        with pytest.raises(ValueError, match="merge_window_seconds must be >= 0"):
+            _validate(cfg)
+
+    def test_min_significant_seconds_must_be_non_negative(self):
+        cfg = {"video_source": "https://youtube.com/test", "min_significant_seconds": -5}
+        with pytest.raises(ValueError, match="min_significant_seconds must be >= 0"):
+            _validate(cfg)
+
+    def test_damping_arrivals_threshold_must_be_integer(self):
+        cfg = {"video_source": "https://youtube.com/test", "damping_arrivals_threshold": 2.5}
+        with pytest.raises(ValueError, match="damping_arrivals_threshold must be an integer"):
+            _validate(cfg)
+
+    def test_damping_window_hours_must_be_positive(self):
+        cfg = {"video_source": "https://youtube.com/test", "damping_window_hours": 0}
+        with pytest.raises(ValueError, match="damping_window_hours must be a positive"):
+            _validate(cfg)
+
+    def test_presence_fraction_keys_range(self):
+        cfg = {"video_source": "https://youtube.com/test", "presence_sustain_confidence": 1.5}
+        with pytest.raises(ValueError, match="presence_sustain_confidence must be between"):
+            _validate(cfg)
+
+    def test_presence_motion_pixel_threshold_range(self):
+        cfg = {"video_source": "https://youtube.com/test", "presence_motion_pixel_threshold": 300}
+        with pytest.raises(ValueError, match="presence_motion_pixel_threshold must be between"):
+            _validate(cfg)
+
+    def test_presence_failsafe_must_exceed_exit_timeout(self):
+        """The absence failsafe must not race the exit_timeout debounce."""
+        cfg = {
+            "video_source": "https://youtube.com/test",
+            "presence_enabled": True,
+            "exit_timeout": 300,
+            "presence_absence_failsafe_seconds": 300,
+        }
+        with pytest.raises(ValueError, match="presence_absence_failsafe_seconds"):
+            _validate(cfg)
+
+    def test_presence_failsafe_not_enforced_when_presence_disabled(self):
+        """With the presence layer off, the failsafe key is inert."""
+        cfg = {
+            "video_source": "https://youtube.com/test",
+            "presence_enabled": False,
+            "exit_timeout": 300,
+            "presence_absence_failsafe_seconds": 60,
+        }
+        _validate(cfg)  # Should not raise
+
+
+class TestGetNowTz:
+    """Behavior of get_now_tz timezone-aware clock."""
+
+    def test_uses_configured_timezone_obj(self):
+        tz = ZoneInfo("America/Chicago")
+        now = get_now_tz({"timezone_obj": tz})
+        assert now.tzinfo is tz
+
+    def test_defaults_to_utc(self):
+        now = get_now_tz({})
+        assert now.tzinfo is timezone.utc
+
+
+class TestLoadEnvFile:
+    """Behavior of the minimal .env loader."""
+
+    def test_missing_file_is_a_noop(self, tmp_path):
+        """A nonexistent .env path does nothing."""
+        before = dict(os.environ)
+        _load_env_file(tmp_path / "nope.env")
+        assert dict(os.environ) == before
+
+    def test_parses_key_value_pairs(self, tmp_path):
+        """KEY=VALUE lines land in os.environ; comments and blanks are skipped."""
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            "# a comment\n"
+            "\n"
+            "KANYO_TEST_ALPHA = hello \n"
+            "KANYO_TEST_BETA=with=equals\n"
+            "NOT_A_PAIR\n"
+            "=orphan_value\n"
+        )
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("KANYO_TEST_ALPHA", None)
+            os.environ.pop("KANYO_TEST_BETA", None)
+            _load_env_file(env_file)
+            assert os.environ["KANYO_TEST_ALPHA"] == "hello"
+            # partition keeps everything after the first '='
+            assert os.environ["KANYO_TEST_BETA"] == "with=equals"
+            assert "NOT_A_PAIR" not in os.environ
+            assert "" not in os.environ
+
+    def test_existing_env_vars_not_overridden(self, tmp_path):
+        """Real environment variables win over .env file values."""
+        env_file = tmp_path / ".env"
+        env_file.write_text("KANYO_TEST_GAMMA=from_file\n")
+        with patch.dict(os.environ, {"KANYO_TEST_GAMMA": "from_env"}):
+            _load_env_file(env_file)
+            assert os.environ["KANYO_TEST_GAMMA"] == "from_env"
+
+
+class TestCast:
+    """Behavior of env-var string casting against a reference default."""
+
+    def test_bool_truthy_values(self):
+        assert _cast("1", True) is True
+        assert _cast("true", False) is True
+        assert _cast("YES", False) is True
+
+    def test_bool_falsy_values(self):
+        assert _cast("0", True) is False
+        assert _cast("no", True) is False
+        assert _cast("anything-else", True) is False
+
+    def test_int(self):
+        assert _cast("42", 5) == 42
+
+    def test_float(self):
+        assert _cast("0.75", 0.5) == 0.75
+
+    def test_string_passthrough(self):
+        assert _cast("rtsp://cam", "") == "rtsp://cam"
+
+
+class TestApplyEnvOverrides:
+    """Behavior of KANYO_<KEY> environment overrides."""
+
+    def test_overrides_typed_values(self, monkeypatch):
+        """Env values are cast to the default's type before overriding."""
+        monkeypatch.setenv("KANYO_DETECTION_CONFIDENCE", "0.75")
+        monkeypatch.setenv("KANYO_FRAME_INTERVAL", "10")
+        monkeypatch.setenv("KANYO_TELEGRAM_ENABLED", "true")
+        monkeypatch.setenv("KANYO_VIDEO_SOURCE", "rtsp://cam")
+        cfg = DEFAULTS.copy()
+
+        _apply_env_overrides(cfg)
+
+        assert cfg["detection_confidence"] == 0.75
+        assert cfg["frame_interval"] == 10
+        assert cfg["telegram_enabled"] is True
+        assert cfg["video_source"] == "rtsp://cam"
+
+    def test_empty_env_value_ignored(self, monkeypatch):
+        """Empty env values do not clobber config values."""
+        monkeypatch.setenv("KANYO_FRAME_INTERVAL", "")
+        cfg = DEFAULTS.copy()
+        cfg["frame_interval"] = 15
+
+        _apply_env_overrides(cfg)
+
+        assert cfg["frame_interval"] == 15
+
+    def test_unset_env_leaves_config_alone(self, monkeypatch):
+        """Keys without a matching env var are untouched."""
+        monkeypatch.delenv("KANYO_DETECTION_CONFIDENCE", raising=False)
+        cfg = DEFAULTS.copy()
+
+        _apply_env_overrides(cfg)
+
+        assert cfg["detection_confidence"] == DEFAULTS["detection_confidence"]
+
+
+class TestParseTimezone:
+    """Behavior of timezone string parsing."""
+
+    def test_empty_and_utc_forms(self):
+        assert _parse_timezone("") == ZoneInfo("UTC")
+        assert _parse_timezone("UTC") == ZoneInfo("UTC")
+        assert _parse_timezone("+00:00") == ZoneInfo("UTC")
+
+    def test_iana_name(self):
+        assert _parse_timezone("America/New_York") == ZoneInfo("America/New_York")
+
+    def test_invalid_iana_name_falls_back_to_utc(self):
+        """A slash-form name that isn't a real zone falls back to UTC."""
+        assert _parse_timezone("Not/AZone") == timezone.utc
+
+    def test_legacy_offset_maps_to_iana(self):
+        """Known legacy offsets map to DST-aware IANA zones."""
+        assert _parse_timezone("-05:00") == ZoneInfo("America/New_York")
+
+    def test_unmapped_offset_becomes_fixed_offset(self):
+        """Offsets with no IANA mapping become fixed-offset timezones."""
+        tz = _parse_timezone("+03:30")
+        assert tz == timezone(timedelta(hours=3, minutes=30))
+
+    def test_negative_unmapped_offset(self):
+        """Negative unmapped offsets keep their sign on hours and minutes."""
+        tz = _parse_timezone("-03:30")
+        assert tz == timezone(timedelta(hours=-3, minutes=-30))
+
+    def test_malformed_offset_falls_back_to_utc(self):
+        """An offset that can't be parsed as numbers falls back to UTC."""
+        assert _parse_timezone("+ab:cd") == timezone.utc
+
+    def test_unrecognized_format_falls_back_to_utc(self):
+        assert _parse_timezone("banana") == timezone.utc
+
+
+class TestLoadConfig:
+    """Behavior of the full load_config pipeline: env > YAML > defaults."""
+
+    def test_yaml_overrides_defaults(self, tmp_path, monkeypatch):
+        """YAML values override defaults; unlisted keys keep their defaults."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "config.yaml").write_text(
+            "video_source: https://youtube.com/test\ndetection_confidence: 0.8\n"
+        )
+
+        cfg = load_config("config.yaml")
+
+        assert cfg["video_source"] == "https://youtube.com/test"
+        assert cfg["detection_confidence"] == 0.8
+        assert cfg["frame_interval"] == DEFAULTS["frame_interval"]
+        assert cfg["timezone_obj"] == ZoneInfo("UTC")
+
+    def test_env_overrides_yaml(self, tmp_path, monkeypatch):
+        """KANYO_* env vars take priority over YAML values."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "config.yaml").write_text(
+            "video_source: https://youtube.com/test\ndetection_confidence: 0.8\n"
+        )
+        monkeypatch.setenv("KANYO_DETECTION_CONFIDENCE", "0.9")
+
+        cfg = load_config("config.yaml")
+
+        assert cfg["detection_confidence"] == 0.9
+
+    def test_missing_yaml_uses_defaults_and_env(self, tmp_path, monkeypatch):
+        """Without a YAML file, defaults plus env overrides are used."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("KANYO_VIDEO_SOURCE", "rtsp://cam")
+
+        cfg = load_config("does-not-exist.yaml")
+
+        assert cfg["video_source"] == "rtsp://cam"
+        assert cfg["detection_confidence"] == DEFAULTS["detection_confidence"]
+
+    def test_empty_yaml_treated_as_empty_mapping(self, tmp_path, monkeypatch):
+        """An empty YAML file is treated as {} rather than crashing."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "config.yaml").write_text("")
+        monkeypatch.setenv("KANYO_VIDEO_SOURCE", "rtsp://cam")
+
+        cfg = load_config("config.yaml")
+
+        assert cfg["video_source"] == "rtsp://cam"
+
+    def test_dotenv_file_loaded(self, tmp_path, monkeypatch):
+        """A .env file in the working directory is loaded into the environment."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "config.yaml").write_text("video_source: https://youtube.com/test\n")
+        (tmp_path / ".env").write_text("KANYO_TEST_SECRET=hunter2\n")
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("KANYO_TEST_SECRET", None)
+            load_config("config.yaml")
+            assert os.environ["KANYO_TEST_SECRET"] == "hunter2"
+
+    def test_timezone_string_parsed_into_timezone_obj(self, tmp_path, monkeypatch):
+        """A timezone string in YAML is parsed into a tzinfo object."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "config.yaml").write_text(
+            "video_source: https://youtube.com/test\ntimezone: America/Chicago\n"
+        )
+
+        cfg = load_config("config.yaml")
+
+        assert cfg["timezone_obj"] == ZoneInfo("America/Chicago")
+
+    def test_non_string_timezone_defaults_to_utc(self, tmp_path, monkeypatch):
+        """A non-string timezone value yields a UTC timezone_obj."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "config.yaml").write_text(
+            "video_source: https://youtube.com/test\ntimezone: null\n"
+        )
+
+        cfg = load_config("config.yaml")
+
+        assert cfg["timezone_obj"] == timezone.utc
+
+    def test_invalid_config_raises(self, tmp_path, monkeypatch):
+        """Validation failures surface as ValueError from load_config."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "config.yaml").write_text(
+            "video_source: https://youtube.com/test\ndetection_confidence: 2.0\n"
+        )
+
+        with pytest.raises(ValueError, match="detection_confidence must be between"):
+            load_config("config.yaml")

--- a/tests/test_detect_coverage.py
+++ b/tests/test_detect_coverage.py
@@ -1,0 +1,129 @@
+"""Tests for kanyo.detection.detect helpers and the package's lazy loading.
+
+Covers Detection serialization, target-class selection, detection helpers,
+and the lazy YOLO model load. The model is never loaded for real: the
+``ultralytics`` module is replaced in sys.modules, so no weights are read.
+YOLO inference itself is specified in test_detection.py.
+"""
+
+import sys
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kanyo.detection.detect import (
+    ANIMAL_CLASS_IDS,
+    BIRD_CLASS_ID,
+    Detection,
+    FalconDetector,
+)
+
+TS = datetime(2026, 7, 16, 12, 0, 0)
+
+
+def make_detection(
+    class_id: int = BIRD_CLASS_ID,
+    class_name: str = "bird",
+    confidence: float = 0.8,
+    bbox: tuple[int, int, int, int] = (10, 20, 30, 40),
+) -> Detection:
+    return Detection(
+        class_id=class_id,
+        class_name=class_name,
+        confidence=confidence,
+        bbox=bbox,
+        timestamp=TS,
+    )
+
+
+class TestDetectionSerialization:
+    """Detection.to_dict produces JSON-ready values."""
+
+    def test_to_dict_rounds_confidence_and_isoformats_timestamp(self):
+        detection = make_detection(confidence=0.87654)
+        d = detection.to_dict()
+
+        assert d == {
+            "class_id": BIRD_CLASS_ID,
+            "class_name": "bird",
+            "confidence": 0.877,
+            "bbox": (10, 20, 30, 40),
+            "timestamp": "2026-07-16T12:00:00",
+        }
+
+
+class TestTargetClassSelection:
+    """__init__ picks target classes from the detect_any_animal switch."""
+
+    def test_any_animal_mode_defaults_to_all_animal_classes(self):
+        detector = FalconDetector(detect_any_animal=True)
+        assert detector.target_classes == list(ANIMAL_CLASS_IDS.keys())
+
+    def test_bird_only_mode_defaults_to_bird_class(self):
+        detector = FalconDetector(detect_any_animal=False)
+        assert detector.target_classes == [BIRD_CLASS_ID]
+
+    def test_bird_only_mode_honors_explicit_target_classes(self):
+        detector = FalconDetector(detect_any_animal=False, target_classes=[14, 15])
+        assert detector.target_classes == [14, 15]
+
+
+class TestLazyModelLoading:
+    """The YOLO model loads on first .model access and is cached after."""
+
+    def test_model_loads_once_from_model_path(self):
+        fake_ultralytics = MagicMock()
+        fake_model = object()
+        fake_ultralytics.YOLO.return_value = fake_model
+
+        detector = FalconDetector(model_path="models/yolov8n.pt")
+        assert detector._model is None  # nothing loaded at construction
+
+        with patch.dict(sys.modules, {"ultralytics": fake_ultralytics}):
+            first = detector.model
+            second = detector.model
+
+        assert first is fake_model
+        assert second is fake_model
+        fake_ultralytics.YOLO.assert_called_once_with("models/yolov8n.pt")
+
+
+class TestDetectionHelpers:
+    """has_bird / get_best_detection operate on detection lists only."""
+
+    def test_has_bird_true_for_target_class(self):
+        detector = FalconDetector(detect_any_animal=False)
+        detections = [
+            make_detection(class_id=15, class_name="cat"),
+            make_detection(class_id=BIRD_CLASS_ID, class_name="bird"),
+        ]
+        assert detector.has_bird(detections) is True
+
+    def test_has_bird_false_for_non_targets_or_empty(self):
+        detector = FalconDetector(detect_any_animal=False)
+        assert detector.has_bird([make_detection(class_id=15, class_name="cat")]) is False
+        assert detector.has_bird([]) is False
+
+    def test_get_best_detection_returns_highest_confidence(self):
+        low = make_detection(confidence=0.4)
+        high = make_detection(confidence=0.9)
+        assert FalconDetector.get_best_detection([low, high]) is high
+
+    def test_get_best_detection_empty_returns_none(self):
+        assert FalconDetector.get_best_detection([]) is None
+
+
+class TestDetectionPackageLazyAttrs:
+    """kanyo.detection exposes heavy classes lazily via __getattr__."""
+
+    def test_lazy_attribute_resolves_to_real_class(self):
+        import kanyo.detection
+
+        assert kanyo.detection.Detection is Detection
+
+    def test_unknown_attribute_raises_attribute_error(self):
+        import kanyo.detection
+
+        with pytest.raises(AttributeError, match="has no attribute 'nonexistent'"):
+            kanyo.detection.nonexistent  # noqa: B018

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -109,10 +109,12 @@ class TestFalconDetector:
         assert str(detector.model_path) == "models/yolov8n.pt"
 
     def test_detect_on_blank_frame(self):
-        """Detection on blank frame returns empty list."""
+        """Detection on a frame with no birds returns an empty list."""
         from kanyo.detection.detect import FalconDetector
 
         detector = FalconDetector()
+        # Mock the model (no YOLO weights needed in test env); no boxes = no birds
+        detector._model = Mock(return_value=_mock_yolo_results([]))
         blank_frame = np.zeros((480, 640, 3), dtype=np.uint8)
         detections = detector.detect(blank_frame)
 

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -122,3 +122,92 @@ class TestDetectHardwareEncoder:
         assert result in valid_encoders
 
         encoder_module._detected_encoder = None
+
+
+class TestDetectHardwareEncoderBranches:
+    """Tests for encoder-specific detection branches (fully mocked subprocess)."""
+
+    @patch("subprocess.run")
+    def test_vaapi_uses_vaapi_device_test_command(self, mock_run, monkeypatch):
+        """VAAPI detection builds a test command with -vaapi_device."""
+        import kanyo.utils.encoder as encoder_module
+
+        monkeypatch.setattr(encoder_module, "_detected_encoder", None)
+
+        test_commands = []
+
+        def fake_run(cmd, **kwargs):
+            if "-encoders" in cmd:
+                # Only VAAPI is listed as available in ffmpeg
+                return MagicMock(stdout="h264_vaapi", returncode=0)
+            test_commands.append(cmd)
+            return MagicMock(returncode=0)
+
+        mock_run.side_effect = fake_run
+
+        result = detect_hardware_encoder()
+
+        assert result == "h264_vaapi"
+        assert len(test_commands) == 1
+        assert "-vaapi_device" in test_commands[0]
+        assert "/dev/dri/renderD128" in test_commands[0]
+        assert "format=nv12,hwupload" in test_commands[0]
+
+    @patch("subprocess.run")
+    def test_test_encode_failure_falls_back_to_libx264(self, mock_run, monkeypatch, capsys):
+        """Encoder listed by ffmpeg but failing its test encode is skipped."""
+        import kanyo.utils.encoder as encoder_module
+
+        monkeypatch.setattr(encoder_module, "_detected_encoder", None)
+
+        def fake_run(cmd, **kwargs):
+            if "-encoders" in cmd:
+                return MagicMock(stdout="h264_nvenc", returncode=0)
+            return MagicMock(returncode=1)  # Test encode fails
+
+        mock_run.side_effect = fake_run
+
+        result = detect_hardware_encoder(verbose=True)
+
+        assert result == "libx264"
+        captured = capsys.readouterr()
+        assert "available but test failed" in captured.out
+
+    @patch("subprocess.run")
+    def test_timeout_during_test_encode_falls_back(self, mock_run, monkeypatch, capsys):
+        """A test encode that hangs (TimeoutExpired) is treated as unavailable."""
+        import subprocess
+
+        import kanyo.utils.encoder as encoder_module
+
+        monkeypatch.setattr(encoder_module, "_detected_encoder", None)
+
+        def fake_run(cmd, **kwargs):
+            if "-encoders" in cmd:
+                return MagicMock(stdout="h264_videotoolbox", returncode=0)
+            raise subprocess.TimeoutExpired(cmd="ffmpeg", timeout=10)
+
+        mock_run.side_effect = fake_run
+
+        result = detect_hardware_encoder(verbose=True)
+
+        assert result == "libx264"
+        captured = capsys.readouterr()
+        assert "timeout during test" in captured.out
+
+    @patch("subprocess.run")
+    def test_ffmpeg_not_found_verbose_reports_and_falls_back(self, mock_run, monkeypatch, capsys):
+        """Missing ffmpeg binary is reported in verbose mode and detection stops."""
+        import kanyo.utils.encoder as encoder_module
+
+        monkeypatch.setattr(encoder_module, "_detected_encoder", None)
+
+        mock_run.side_effect = FileNotFoundError("ffmpeg not found")
+
+        result = detect_hardware_encoder(verbose=True)
+
+        assert result == "libx264"
+        captured = capsys.readouterr()
+        assert "ffmpeg not found" in captured.out
+        # The loop breaks on the first FileNotFoundError instead of retrying
+        assert mock_run.call_count == 1

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -94,6 +94,28 @@ class TestFalconVisit:
         )
         assert not completed.is_active
 
+    def test_ongoing_visit_has_no_duration(self):
+        """A visit without an end time has no duration and reads 'ongoing'."""
+        from kanyo.detection.events import FalconVisit
+
+        visit = FalconVisit(start_time=datetime(2025, 12, 17, 10, 0, 0))
+
+        assert visit.duration is None
+        assert visit.duration_seconds == 0
+        assert visit.duration_str == "ongoing"
+
+    def test_duration_str_with_hours(self):
+        """Visits longer than an hour render as 'Xh Ym'."""
+        from kanyo.detection.events import FalconVisit
+
+        start = datetime(2025, 12, 17, 10, 0, 0)
+        visit = FalconVisit(
+            start_time=start,
+            end_time=start + timedelta(hours=2, minutes=5, seconds=30),
+        )
+
+        assert visit.duration_str == "2h 5m"
+
     def test_to_dict(self):
         """FalconVisit serializes to dict."""
         from kanyo.detection.events import FalconVisit
@@ -141,8 +163,9 @@ class TestEventStore:
 
     def test_append_and_load(self):
         """Events can be appended and reloaded."""
-        from kanyo.detection.events import EventStore, FalconVisit
         from zoneinfo import ZoneInfo
+
+        from kanyo.detection.events import EventStore, FalconVisit
 
         with TemporaryDirectory() as tmpdir:
             clips_dir = Path(tmpdir) / "clips"
@@ -168,8 +191,9 @@ class TestEventStore:
 
     def test_multiple_appends(self):
         """Multiple events accumulate."""
-        from kanyo.detection.events import EventStore, FalconVisit
         from zoneinfo import ZoneInfo
+
+        from kanyo.detection.events import EventStore, FalconVisit
 
         with TemporaryDirectory() as tmpdir:
             clips_dir = Path(tmpdir) / "clips"
@@ -194,8 +218,9 @@ class TestEventStore:
 
     def test_get_today_visits(self):
         """get_today_visits filters by date."""
-        from kanyo.detection.events import EventStore, FalconVisit
         from zoneinfo import ZoneInfo
+
+        from kanyo.detection.events import EventStore, FalconVisit
 
         with TemporaryDirectory() as tmpdir:
             clips_dir = Path(tmpdir) / "clips"
@@ -216,8 +241,9 @@ class TestEventStore:
 
     def test_json_file_format(self):
         """Events are stored as valid JSON."""
-        from kanyo.detection.events import EventStore, FalconVisit
         from zoneinfo import ZoneInfo
+
+        from kanyo.detection.events import EventStore, FalconVisit
 
         with TemporaryDirectory() as tmpdir:
             clips_dir = Path(tmpdir) / "clips"
@@ -236,3 +262,57 @@ class TestEventStore:
                 data = json.load(f)
             assert isinstance(data, list)
             assert len(data) == 1
+
+    def test_event_record_files_under_its_own_timestamp_date(self):
+        """An EventRecord lands in the date file of its own tz-aware timestamp."""
+        from zoneinfo import ZoneInfo
+
+        from kanyo.detection.events import EventRecord, EventStore
+
+        with TemporaryDirectory() as tmpdir:
+            clips_dir = Path(tmpdir) / "clips"
+            store = EventStore(
+                clips_dir=clips_dir,
+                timezone_config={"timezone": "Australia/Sydney"},
+            )
+
+            ts = datetime(2026, 7, 1, 10, 30, 0, tzinfo=ZoneInfo("Australia/Sydney"))
+            event = EventRecord(event_type="falcon_enter", timestamp=ts, confidence=0.9)
+            store.append(event)
+
+            events_file = clips_dir / "2026-07-01" / "events_2026-07-01.json"
+            assert events_file.exists()
+            loaded = store.load(events_file)
+            assert loaded[0]["event_type"] == "falcon_enter"
+
+    def test_naive_timestamp_falls_back_to_stream_local_today(self):
+        """A naive timestamp (shouldn't happen) files under today's date in
+        the stream's local timezone rather than crashing."""
+        from kanyo.detection.events import EventStore, FalconVisit
+        from kanyo.utils.config import get_now_tz
+
+        with TemporaryDirectory() as tmpdir:
+            clips_dir = Path(tmpdir) / "clips"
+            timezone_config = {"timezone": "Australia/Sydney"}
+            store = EventStore(clips_dir=clips_dir, timezone_config=timezone_config)
+
+            naive_visit = FalconVisit(start_time=datetime(2020, 1, 1, 0, 0, 0))
+            date_str = store._get_event_date(naive_visit)
+
+            # Not the naive timestamp's date — the stream-local "today".
+            assert date_str != "2020-01-01"
+            assert date_str == get_now_tz(timezone_config).strftime("%Y-%m-%d")
+
+    def test_corrupted_events_file_returns_empty(self):
+        """A corrupted JSON file is treated as a fresh (empty) event list."""
+        from kanyo.detection.events import EventStore
+
+        with TemporaryDirectory() as tmpdir:
+            clips_dir = Path(tmpdir) / "clips"
+            store = EventStore(clips_dir=clips_dir)
+
+            events_path = clips_dir / "2026-07-01" / "events_2026-07-01.json"
+            events_path.parent.mkdir(parents=True)
+            events_path.write_text("{not valid json")
+
+            assert store.load(events_path) == []

--- a/tests/test_falcon_state.py
+++ b/tests/test_falcon_state.py
@@ -679,3 +679,78 @@ class TestStreamRecovery:
         # Should stay in PENDING_RECOVERY - buffer_monitor handles confirmation
         assert fsm.state == FalconState.PENDING_RECOVERY
         assert len(events) == 0
+
+
+class TestPendingStartupAbsence:
+    """Absence while PENDING_STARTUP defers to buffer_monitor's ratio check."""
+
+    def test_absence_during_pending_startup_generates_no_events(self):
+        """No detection during PENDING_STARTUP: state holds, no events —
+        confirmation failure is buffer_monitor's call, not the machine's."""
+        config = {"exit_timeout": 90}
+        fsm = FalconStateMachine(config)
+        t0 = datetime.now()
+
+        fsm.set_pending_startup(t0)
+        events = fsm.update(falcon_detected=False, timestamp=t0 + timedelta(seconds=30))
+
+        assert events == []
+        assert fsm.state == FalconState.PENDING_STARTUP
+
+
+class TestConfirmationGuards:
+    """Confirmation/cancel calls in the wrong state are ignored loudly."""
+
+    def test_confirm_startup_ignored_outside_pending_startup(self):
+        """confirm_startup_presence from ABSENT is a no-op."""
+        config = {}
+        fsm = FalconStateMachine(config)
+        t0 = datetime.now()
+
+        fsm.confirm_startup_presence(t0)
+
+        assert fsm.state == FalconState.ABSENT
+        assert fsm.roosting_start is None
+
+    def test_confirm_startup_backfills_missing_visit_start(self):
+        """A PENDING_STARTUP entered without visit context still gets a
+        visit_start on confirmation, so departure durations compute."""
+        config = {}
+        fsm = FalconStateMachine(config)
+        t0 = datetime.now()
+
+        fsm.state = FalconState.PENDING_STARTUP
+        fsm.visit_start = None
+        fsm.confirm_startup_presence(t0)
+
+        assert fsm.state == FalconState.ROOSTING
+        assert fsm.visit_start == t0
+        assert fsm.roosting_start == t0
+
+    def test_cancel_recovery_ignored_outside_pending_recovery(self):
+        """cancel_recovery from ABSENT returns no events and changes nothing."""
+        config = {}
+        fsm = FalconStateMachine(config)
+        t0 = datetime.now()
+
+        events = fsm.cancel_recovery(t0)
+
+        assert events == []
+        assert fsm.state == FalconState.ABSENT
+
+
+class TestPendingRecoveryFromUnexpectedState:
+    """set_pending_recovery outside VISITING/ROOSTING falls back to VISITING."""
+
+    def test_pending_recovery_from_absent_defaults_to_visiting(self):
+        """Recovery entered from a non-present state records VISITING as the
+        pre-outage state with no roosting context."""
+        config = {}
+        fsm = FalconStateMachine(config)
+        t0 = datetime.now()
+
+        fsm.set_pending_recovery(t0)
+
+        assert fsm.state == FalconState.PENDING_RECOVERY
+        assert fsm.pre_outage_state == FalconState.VISITING
+        assert fsm.pre_outage_roosting_start is None

--- a/tests/test_frame_buffer.py
+++ b/tests/test_frame_buffer.py
@@ -1,10 +1,37 @@
 """Tests for frame buffer module."""
 
 from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
 
+import cv2
 import numpy as np
 
 from kanyo.utils.frame_buffer import BufferedFrame, FrameBuffer
+
+
+def _make_real_frame(
+    timestamp: datetime | None = None,
+    frame_number: int = 0,
+    size: tuple[int, int] = (8, 8),
+) -> BufferedFrame:
+    """Build a BufferedFrame around a real tiny JPEG."""
+    img = np.zeros((size[0], size[1], 3), dtype=np.uint8)
+    success, jpeg = cv2.imencode(".jpg", img)
+    assert success
+    return BufferedFrame(
+        timestamp=timestamp or datetime.now(),
+        frame_number=frame_number,
+        jpeg_data=jpeg.tobytes(),
+    )
+
+
+def _make_ffmpeg_process(returncode: int = 0, stderr: bytes = b"") -> MagicMock:
+    """Mock subprocess.Popen result mimicking a piped ffmpeg process."""
+    process = MagicMock()
+    process.stdin = MagicMock()
+    process.communicate.return_value = (b"", stderr)
+    process.returncode = returncode
+    return process
 
 
 class TestBufferedFrame:
@@ -237,3 +264,232 @@ class TestFrameBufferProperties:
             buffer.add_frame(frame, datetime.now(), frame_number=i)
 
         assert buffer.duration_seconds == 5.0
+
+
+class TestFrameBufferAddFrameFailure:
+    """Tests for JPEG encode failure handling."""
+
+    def test_add_frame_encode_failure_drops_frame(self):
+        """A frame that fails JPEG encoding is dropped, not buffered."""
+        buffer = FrameBuffer(buffer_seconds=10, fps=1)
+        frame = np.zeros((50, 50, 3), dtype=np.uint8)
+
+        with patch("cv2.imencode", return_value=(False, None)):
+            buffer.add_frame(frame, datetime.now(), frame_number=7)
+
+        assert len(buffer) == 0
+
+
+class TestFrameBufferGetRecentFramesEmpty:
+    """Tests for get_recent_frames on an empty buffer."""
+
+    def test_get_recent_frames_empty_buffer(self):
+        """Empty buffer yields an empty list without error."""
+        buffer = FrameBuffer(buffer_seconds=10, fps=1)
+        assert buffer.get_recent_frames(seconds=5) == []
+
+
+class TestFrameBufferExtractClip:
+    """Tests for extract_clip (mocked ffmpeg subprocess)."""
+
+    def _fill_buffer(self, buffer: FrameBuffer, count: int, start_time: datetime) -> None:
+        for i in range(count):
+            frame = np.zeros((8, 8, 3), dtype=np.uint8)
+            buffer.add_frame(frame, start_time + timedelta(seconds=i), frame_number=i)
+
+    def test_extract_clip_no_frames_in_range(self, tmp_path):
+        """Extraction fails cleanly when the range contains no frames."""
+        buffer = FrameBuffer(buffer_seconds=10, fps=1)
+        base_time = datetime(2024, 1, 1, 12, 0, 0)
+
+        result = buffer.extract_clip(
+            base_time,
+            base_time + timedelta(seconds=5),
+            tmp_path / "clip.mp4",
+        )
+
+        assert result is False
+
+    @patch("kanyo.utils.frame_buffer.detect_hardware_encoder", return_value="libx264")
+    @patch("subprocess.Popen")
+    def test_extract_clip_success(self, mock_popen, mock_encoder, tmp_path):
+        """Frames in range are piped to ffmpeg and success is reported."""
+        mock_process = _make_ffmpeg_process(returncode=0)
+        mock_popen.return_value = mock_process
+
+        buffer = FrameBuffer(buffer_seconds=30, fps=1)
+        base_time = datetime(2024, 1, 1, 12, 0, 0)
+        self._fill_buffer(buffer, 10, base_time)
+
+        output_path = tmp_path / "out" / "clip.mp4"
+        result = buffer.extract_clip(
+            base_time,
+            base_time + timedelta(seconds=4),
+            output_path,
+        )
+
+        assert result is True
+        # One raw frame write per buffered frame in range (5 frames: 0-4)
+        assert mock_process.stdin.write.call_count == 5
+        mock_process.stdin.close.assert_called_once()
+        # Output directory was created for ffmpeg
+        assert output_path.parent.exists()
+        # Buffer fps used when fps arg is None
+        cmd = mock_popen.call_args[0][0]
+        assert "-r" in cmd
+        assert cmd[cmd.index("-r") + 1] == "1"
+
+    @patch("kanyo.utils.frame_buffer.detect_hardware_encoder", return_value="libx264")
+    @patch("subprocess.Popen")
+    def test_extract_clip_explicit_fps_overrides_buffer_fps(
+        self, mock_popen, mock_encoder, tmp_path
+    ):
+        """An explicit fps argument overrides the buffer's fps."""
+        mock_popen.return_value = _make_ffmpeg_process(returncode=0)
+
+        buffer = FrameBuffer(buffer_seconds=30, fps=1)
+        base_time = datetime(2024, 1, 1, 12, 0, 0)
+        self._fill_buffer(buffer, 5, base_time)
+
+        result = buffer.extract_clip(
+            base_time,
+            base_time + timedelta(seconds=4),
+            tmp_path / "clip.mp4",
+            fps=24,
+        )
+
+        assert result is True
+        cmd = mock_popen.call_args[0][0]
+        assert cmd[cmd.index("-r") + 1] == "24"
+
+
+class TestWriteFramesToVideo:
+    """Tests for _write_frames_to_video internals (mocked ffmpeg subprocess)."""
+
+    def test_empty_frames_returns_false(self, tmp_path):
+        """No frames means nothing to write."""
+        buffer = FrameBuffer(buffer_seconds=10, fps=1)
+        result = buffer._write_frames_to_video([], tmp_path / "clip.mp4", fps=30, crf=23)
+        assert result is False
+
+    def test_undecodable_first_frame_returns_false(self, tmp_path):
+        """Corrupt first frame aborts before ffmpeg is launched."""
+        buffer = FrameBuffer(buffer_seconds=10, fps=1)
+        bad_frame = BufferedFrame(
+            timestamp=datetime.now(),
+            frame_number=0,
+            jpeg_data=b"not a jpeg",
+        )
+
+        with patch("subprocess.Popen") as mock_popen:
+            result = buffer._write_frames_to_video(
+                [bad_frame], tmp_path / "clip.mp4", fps=30, crf=23
+            )
+
+        assert result is False
+        mock_popen.assert_not_called()
+
+    @patch("subprocess.Popen")
+    def test_videotoolbox_encoder_options(self, mock_popen, tmp_path):
+        """VideoToolbox encoder maps crf to a -q:v quality value."""
+        mock_popen.return_value = _make_ffmpeg_process(returncode=0)
+        buffer = FrameBuffer(buffer_seconds=10, fps=1)
+
+        with patch(
+            "kanyo.utils.frame_buffer.detect_hardware_encoder",
+            return_value="h264_videotoolbox",
+        ):
+            result = buffer._write_frames_to_video(
+                [_make_real_frame()], tmp_path / "clip.mp4", fps=30, crf=23
+            )
+
+        assert result is True
+        cmd = mock_popen.call_args[0][0]
+        assert "h264_videotoolbox" in cmd
+        assert "-q:v" in cmd
+        assert cmd[cmd.index("-q:v") + 1] == str((51 - 23) * 2)
+
+    @patch("subprocess.Popen")
+    def test_vaapi_encoder_options(self, mock_popen, tmp_path):
+        """VAAPI encoder adds the render device and hwupload filter."""
+        mock_popen.return_value = _make_ffmpeg_process(returncode=0)
+        buffer = FrameBuffer(buffer_seconds=10, fps=1)
+
+        with patch(
+            "kanyo.utils.frame_buffer.detect_hardware_encoder",
+            return_value="h264_vaapi",
+        ):
+            result = buffer._write_frames_to_video(
+                [_make_real_frame()], tmp_path / "clip.mp4", fps=30, crf=23
+            )
+
+        assert result is True
+        cmd = mock_popen.call_args[0][0]
+        assert "h264_vaapi" in cmd
+        assert "-vaapi_device" in cmd
+        assert "format=nv12,hwupload" in cmd
+
+    @patch("subprocess.Popen")
+    def test_nvenc_encoder_options(self, mock_popen, tmp_path):
+        """NVENC encoder uses -cq quality control."""
+        mock_popen.return_value = _make_ffmpeg_process(returncode=0)
+        buffer = FrameBuffer(buffer_seconds=10, fps=1)
+
+        with patch(
+            "kanyo.utils.frame_buffer.detect_hardware_encoder",
+            return_value="h264_nvenc",
+        ):
+            result = buffer._write_frames_to_video(
+                [_make_real_frame()], tmp_path / "clip.mp4", fps=30, crf=23
+            )
+
+        assert result is True
+        cmd = mock_popen.call_args[0][0]
+        assert "h264_nvenc" in cmd
+        assert "-cq" in cmd
+
+    @patch("subprocess.Popen")
+    def test_libx264_encoder_options(self, mock_popen, tmp_path):
+        """Software fallback uses libx264 with -crf."""
+        mock_popen.return_value = _make_ffmpeg_process(returncode=0)
+        buffer = FrameBuffer(buffer_seconds=10, fps=1)
+
+        with patch(
+            "kanyo.utils.frame_buffer.detect_hardware_encoder",
+            return_value="libx264",
+        ):
+            result = buffer._write_frames_to_video(
+                [_make_real_frame()], tmp_path / "clip.mp4", fps=30, crf=18
+            )
+
+        assert result is True
+        cmd = mock_popen.call_args[0][0]
+        assert "libx264" in cmd
+        assert "-crf" in cmd
+        assert cmd[cmd.index("-crf") + 1] == "18"
+
+    @patch("kanyo.utils.frame_buffer.detect_hardware_encoder", return_value="libx264")
+    @patch("subprocess.Popen")
+    def test_ffmpeg_nonzero_exit_returns_false(self, mock_popen, mock_encoder, tmp_path):
+        """A non-zero ffmpeg exit code is reported as failure."""
+        mock_popen.return_value = _make_ffmpeg_process(returncode=1, stderr=b"encode error")
+        buffer = FrameBuffer(buffer_seconds=10, fps=1)
+
+        result = buffer._write_frames_to_video(
+            [_make_real_frame()], tmp_path / "clip.mp4", fps=30, crf=23
+        )
+
+        assert result is False
+
+    @patch("kanyo.utils.frame_buffer.detect_hardware_encoder", return_value="libx264")
+    @patch("subprocess.Popen")
+    def test_popen_exception_returns_false(self, mock_popen, mock_encoder, tmp_path):
+        """An OS-level failure launching ffmpeg is caught and reported."""
+        mock_popen.side_effect = OSError("ffmpeg not found")
+        buffer = FrameBuffer(buffer_seconds=10, fps=1)
+
+        result = buffer._write_frames_to_video(
+            [_make_real_frame()], tmp_path / "clip.mp4", fps=30, crf=23
+        )
+
+        assert result is False

--- a/tests/test_log_service.py
+++ b/tests/test_log_service.py
@@ -2,10 +2,10 @@
 Tests for log service (file-based log reading).
 """
 
-import tempfile
-from datetime import datetime, timezone, timedelta
-from pathlib import Path
 import sys
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
 # Import from admin web app
 sys.path.insert(0, str(Path(__file__).parent.parent / "admin" / "web"))

--- a/tests/test_log_service.py
+++ b/tests/test_log_service.py
@@ -13,6 +13,17 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "admin" / "web"))
 from app.services import log_service  # noqa: E402
 
 
+def _recent_ts(offset_seconds: int) -> str:
+    """
+    Timestamp string offset from a fixed base 30 minutes ago (UTC).
+
+    Keeps test log lines inside any since-window ("1h", "24h", ...) regardless
+    of the date the suite runs on.
+    """
+    base = datetime.now(timezone.utc) - timedelta(minutes=30)
+    return (base + timedelta(seconds=offset_seconds)).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+
 class TestParseLogLine:
     """Test log line parsing."""
 
@@ -282,14 +293,14 @@ class TestShowContext:
         """When show_context=True, include DEBUG lines before/after EVENT logs."""
         with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".log") as f:
             # Write logs with DEBUG lines surrounding an EVENT
-            f.write("2026-01-11 12:00:00 UTC | DEBUG    | kanyo | Detection check 1\n")
-            f.write("2026-01-11 12:00:01 UTC | DEBUG    | kanyo | Detection check 2\n")
-            f.write("2026-01-11 12:00:02 UTC | DEBUG    | kanyo | Detection check 3\n")
-            f.write("2026-01-11 12:00:03 UTC | EVENT    | kanyo | Falcon detected - arrival\n")
-            f.write("2026-01-11 12:00:04 UTC | DEBUG    | kanyo | Detection check 4\n")
-            f.write("2026-01-11 12:00:05 UTC | DEBUG    | kanyo | Detection check 5\n")
-            f.write("2026-01-11 12:00:06 UTC | DEBUG    | kanyo | Detection check 6\n")
-            f.write("2026-01-11 12:00:07 UTC | INFO     | kanyo | Some other log\n")
+            f.write(f"{_recent_ts(0)} | DEBUG    | kanyo | Detection check 1\n")
+            f.write(f"{_recent_ts(1)} | DEBUG    | kanyo | Detection check 2\n")
+            f.write(f"{_recent_ts(2)} | DEBUG    | kanyo | Detection check 3\n")
+            f.write(f"{_recent_ts(3)} | EVENT    | kanyo | Falcon detected - arrival\n")
+            f.write(f"{_recent_ts(4)} | DEBUG    | kanyo | Detection check 4\n")
+            f.write(f"{_recent_ts(5)} | DEBUG    | kanyo | Detection check 5\n")
+            f.write(f"{_recent_ts(6)} | DEBUG    | kanyo | Detection check 6\n")
+            f.write(f"{_recent_ts(7)} | INFO     | kanyo | Some other log\n")
             log_path = Path(f.name)
 
         # Create mock data directory structure
@@ -339,10 +350,10 @@ class TestShowContext:
     def test_show_context_false_only_shows_requested_levels(self):
         """When show_context=False, only show requested log levels."""
         with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".log") as f:
-            f.write("2026-01-11 12:00:00 UTC | DEBUG    | kanyo | Debug line 1\n")
-            f.write("2026-01-11 12:00:01 UTC | EVENT    | kanyo | Event line\n")
-            f.write("2026-01-11 12:00:02 UTC | DEBUG    | kanyo | Debug line 2\n")
-            f.write("2026-01-11 12:00:03 UTC | INFO     | kanyo | Info line\n")
+            f.write(f"{_recent_ts(0)} | DEBUG    | kanyo | Debug line 1\n")
+            f.write(f"{_recent_ts(1)} | EVENT    | kanyo | Event line\n")
+            f.write(f"{_recent_ts(2)} | DEBUG    | kanyo | Debug line 2\n")
+            f.write(f"{_recent_ts(3)} | INFO     | kanyo | Info line\n")
             log_path = Path(f.name)
 
         data_dir = Path(tempfile.mkdtemp())
@@ -372,13 +383,13 @@ class TestShowContext:
     def test_show_context_with_multiple_events(self):
         """Context should be added for each EVENT independently."""
         with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".log") as f:
-            f.write("2026-01-11 12:00:00 UTC | DEBUG    | kanyo | Before event 1 - line 1\n")
-            f.write("2026-01-11 12:00:01 UTC | EVENT    | kanyo | Event 1\n")
-            f.write("2026-01-11 12:00:02 UTC | DEBUG    | kanyo | After event 1 - line 1\n")
-            f.write("2026-01-11 12:00:03 UTC | INFO     | kanyo | Info between events\n")
-            f.write("2026-01-11 12:00:04 UTC | DEBUG    | kanyo | Before event 2 - line 1\n")
-            f.write("2026-01-11 12:00:05 UTC | EVENT    | kanyo | Event 2\n")
-            f.write("2026-01-11 12:00:06 UTC | DEBUG    | kanyo | After event 2 - line 1\n")
+            f.write(f"{_recent_ts(0)} | DEBUG    | kanyo | Before event 1 - line 1\n")
+            f.write(f"{_recent_ts(1)} | EVENT    | kanyo | Event 1\n")
+            f.write(f"{_recent_ts(2)} | DEBUG    | kanyo | After event 1 - line 1\n")
+            f.write(f"{_recent_ts(3)} | INFO     | kanyo | Info between events\n")
+            f.write(f"{_recent_ts(4)} | DEBUG    | kanyo | Before event 2 - line 1\n")
+            f.write(f"{_recent_ts(5)} | EVENT    | kanyo | Event 2\n")
+            f.write(f"{_recent_ts(6)} | DEBUG    | kanyo | After event 2 - line 1\n")
             log_path = Path(f.name)
 
         data_dir = Path(tempfile.mkdtemp())

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,8 +1,24 @@
-"""Tests for custom EVENT log level."""
+"""Tests for custom EVENT log level, UTC formatting, and DEBUG buffering."""
 
 import logging
+from datetime import datetime, timezone
+from unittest.mock import Mock, patch
 
-from kanyo.utils.logger import get_logger, EVENT
+from kanyo.utils.logger import (
+    DEFAULT_LEVEL,
+    DEFAULT_LOG_FILE,
+    EVENT,
+    BufferedDebugHandler,
+    UTCFormatter,
+    get_logger,
+    setup_logging,
+    setup_logging_from_config,
+)
+
+
+def make_record(level: int, msg: str = "message") -> logging.LogRecord:
+    """A bare LogRecord at the given level."""
+    return logging.LogRecord("test_logger", level, __file__, 1, msg, None, None)
 
 
 class TestEventLogLevel:
@@ -98,3 +114,116 @@ class TestEventLogLevel:
 
         assert len(caplog.records) == 1
         assert caplog.records[0].custom_field == "value"
+
+
+class TestUTCFormatter:
+    """Log timestamps are always rendered in UTC."""
+
+    def test_format_time_default_format_is_utc(self):
+        """Without a datefmt, formatTime renders UTC as Y-m-d H:M:S."""
+        formatter = UTCFormatter()
+        record = make_record(logging.INFO)
+        record.created = datetime(2026, 1, 1, 12, 30, 45, tzinfo=timezone.utc).timestamp()
+
+        assert formatter.formatTime(record) == "2026-01-01 12:30:45"
+
+    def test_format_time_honors_custom_datefmt(self):
+        formatter = UTCFormatter()
+        record = make_record(logging.INFO)
+        record.created = datetime(2026, 1, 1, 12, 30, 45, tzinfo=timezone.utc).timestamp()
+
+        assert formatter.formatTime(record, datefmt="%H:%M") == "12:30"
+
+
+class TestBufferedDebugHandler:
+    """Smart DEBUG buffering: buffer quietly, flush around events."""
+
+    def make_handler(self, tmp_path, **kwargs) -> tuple[BufferedDebugHandler, "object"]:
+        log_file = tmp_path / "kanyo.log"
+        handler = BufferedDebugHandler(str(log_file), **kwargs)
+        handler.setFormatter(logging.Formatter("%(levelname)s | %(message)s"))
+        return handler, log_file
+
+    def test_debug_is_buffered_not_written(self, tmp_path):
+        """Outside a capture window, DEBUG goes to the ring buffer only."""
+        handler, log_file = self.make_handler(tmp_path)
+        try:
+            handler.emit(make_record(logging.DEBUG, "quiet context"))
+            handler.flush()
+
+            assert "quiet context" not in log_file.read_text()
+            assert len(handler._debug_buffer) == 1
+        finally:
+            handler.close()
+
+    def test_event_flushes_buffered_debug_before_itself(self, tmp_path):
+        """An EVENT-or-higher record flushes the DEBUG context ahead of it."""
+        handler, log_file = self.make_handler(tmp_path)
+        try:
+            handler.emit(make_record(logging.DEBUG, "context before"))
+            handler.emit(make_record(logging.WARNING, "the event"))
+
+            content = log_file.read_text()
+            assert content.index("context before") < content.index("the event")
+            assert len(handler._debug_buffer) == 0
+        finally:
+            handler.close()
+
+    def test_debug_written_directly_during_capture_window(self, tmp_path):
+        """After an event, DEBUG passes straight to file for the window."""
+        handler, log_file = self.make_handler(tmp_path, capture_window=60.0)
+        try:
+            handler.emit(make_record(logging.WARNING, "the event"))
+            handler.emit(make_record(logging.DEBUG, "context after"))
+            handler.flush()
+
+            assert "context after" in log_file.read_text()
+            assert len(handler._debug_buffer) == 0
+        finally:
+            handler.close()
+
+    def test_emit_failure_routes_to_handle_error(self, tmp_path):
+        """A formatting failure never propagates — logging must not crash
+        the pipeline; the record goes to handleError."""
+        handler, _ = self.make_handler(tmp_path)
+        try:
+            handler.format = Mock(side_effect=ValueError("bad format"))
+            handler.handleError = Mock()
+
+            record = make_record(logging.DEBUG, "unformattable")
+            handler.emit(record)
+
+            handler.handleError.assert_called_once_with(record)
+        finally:
+            handler.close()
+
+
+class TestSetupLogging:
+    """setup_logging is idempotent; config values pass through."""
+
+    def test_repeat_setup_updates_level_without_duplicating_handlers(self):
+        """A second setup_logging call re-levels the root logger but never
+        stacks duplicate handlers."""
+        get_logger("test_setup_idempotent")  # guarantees initialization
+        root = logging.getLogger()
+        handlers_before = list(root.handlers)
+        level_before = root.level
+
+        try:
+            setup_logging("WARNING")
+            assert root.handlers == handlers_before
+            assert root.level == logging.WARNING
+        finally:
+            root.setLevel(level_before)
+
+    def test_setup_logging_from_config_passes_values(self):
+        with patch("kanyo.utils.logger.setup_logging") as mock_setup:
+            setup_logging_from_config({"log_level": "DEBUG", "log_file": "logs/custom.log"})
+
+        mock_setup.assert_called_once_with(level="DEBUG", log_file="logs/custom.log")
+
+    def test_setup_logging_from_config_defaults(self):
+        with patch("kanyo.utils.logger.setup_logging") as mock_setup:
+            setup_logging_from_config({})
+
+        mock_setup.assert_called_once_with(level=DEFAULT_LEVEL, log_file=DEFAULT_LOG_FILE)

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,8 +1,10 @@
 """Tests for NotificationManager."""
+
 import tempfile
 from datetime import datetime, timedelta
 from pathlib import Path
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import MagicMock, Mock, patch
+
 import pytest
 
 from kanyo.utils.notifications import NotificationManager
@@ -207,3 +209,112 @@ class TestAdminNotifications:
         ):
             # Should not raise
             mgr._send_admin_notification("error msg", "Title")
+
+    def test_send_admin_notification_non_2xx_logged_not_raised(self):
+        """A non-2xx ntfy response is logged as a warning, never raised."""
+        mgr = _make_manager(ntfy_admin_enabled=True)
+        mock_resp = Mock(status_code=500)
+        with patch("kanyo.utils.notifications.requests.post", return_value=mock_resp) as mock_post:
+            # Should not raise
+            mgr._send_admin_notification("an error", "Title")
+        mock_post.assert_called_once()
+
+    def test_send_admin_notification_includes_title_header(self):
+        """The notification title travels as the ntfy Title header."""
+        mgr = _make_manager(ntfy_admin_enabled=True)
+        mock_resp = Mock(status_code=200)
+        with patch("kanyo.utils.notifications.requests.post", return_value=mock_resp) as mock_post:
+            mgr.send_system_alert("stream down", title="Kanyo System Alert")
+        headers = mock_post.call_args.kwargs["headers"]
+        assert headers["Title"] == "Kanyo System Alert"
+
+
+class TestSendActivitySummary:
+    def test_returns_false_when_disabled(self):
+        """Summaries are dropped when Telegram is disabled."""
+        mgr = _make_manager()
+        assert mgr.send_activity_summary("9 visits in the last hour") is False
+
+    def test_sends_text_message_when_enabled(self):
+        """An enabled manager sends the summary as a text-only message."""
+        mgr = _make_manager(telegram_enabled=True)
+        mock_resp = Mock(status_code=200)
+        with patch("kanyo.utils.notifications.requests.post", return_value=mock_resp) as mock_post:
+            result = mgr.send_activity_summary("9 visits in the last hour, median 25s")
+
+        assert result is True
+        url = mock_post.call_args[0][0]
+        assert "sendMessage" in url
+        data = mock_post.call_args.kwargs["data"]
+        assert data["text"] == "9 visits in the last hour, median 25s"
+        assert data["chat_id"] == "@testchan"
+
+
+class TestSendTelegramText:
+    def test_success_returns_true(self):
+        mgr = _make_manager(telegram_enabled=True)
+        mock_resp = Mock(status_code=200)
+        with patch("kanyo.utils.notifications.requests.post", return_value=mock_resp) as mock_post:
+            result = mgr._send_telegram_text("hello")
+
+        assert result is True
+        url = mock_post.call_args[0][0]
+        assert url == "https://api.telegram.org/bottesttoken/sendMessage"
+
+    def test_api_error_reports_to_admin(self):
+        """A non-200 Telegram response fails and pings the admin channel."""
+        mgr = _make_manager(telegram_enabled=True, ntfy_admin_enabled=True)
+        telegram_resp = Mock(status_code=403, text="Forbidden: bot was blocked")
+        ntfy_resp = Mock(status_code=200)
+        with patch(
+            "kanyo.utils.notifications.requests.post",
+            side_effect=[telegram_resp, ntfy_resp],
+        ) as mock_post:
+            result = mgr._send_telegram_text("hello")
+
+        assert result is False
+        # Second post is the admin-error notification to ntfy
+        assert mock_post.call_count == 2
+        assert "ntfy.sh/testtopic" in mock_post.call_args_list[1][0][0]
+
+    def test_timeout_returns_false(self):
+        import requests as req
+
+        mgr = _make_manager(telegram_enabled=True)
+        with patch(
+            "kanyo.utils.notifications.requests.post",
+            side_effect=req.Timeout("timed out"),
+        ):
+            assert mgr._send_telegram_text("hello") is False
+
+    def test_connection_error_returns_false(self):
+        import requests as req
+
+        mgr = _make_manager(telegram_enabled=True)
+        with patch(
+            "kanyo.utils.notifications.requests.post",
+            side_effect=req.ConnectionError("refused"),
+        ):
+            assert mgr._send_telegram_text("hello") is False
+
+    def test_unexpected_error_returns_false(self):
+        mgr = _make_manager(telegram_enabled=True)
+        with patch(
+            "kanyo.utils.notifications.requests.post",
+            side_effect=ValueError("boom"),
+        ):
+            assert mgr._send_telegram_text("hello") is False
+
+
+class TestSendTelegramPhotoUnexpectedError:
+    def test_unexpected_error_returns_false(self, tmp_path):
+        """A non-requests exception during photo send is caught and reported."""
+        mgr = _make_manager(telegram_enabled=True)
+        thumb = tmp_path / "t.jpg"
+        thumb.write_bytes(b"data")
+
+        with patch(
+            "kanyo.utils.notifications.requests.post",
+            side_effect=ValueError("boom"),
+        ):
+            assert mgr._send_telegram_photo("caption", thumb) is False

--- a/tests/test_presence.py
+++ b/tests/test_presence.py
@@ -352,3 +352,43 @@ class TestReset:
 
         # Absent again: enter stays strict.
         assert tracker.update(make_frame(blob), ts(5), [], []) is False
+
+
+class TestRegionGuards:
+    """Degenerate region mapping and defensive guards on region helpers."""
+
+    def test_resolution_drop_maps_region_off_frame_keeps_parked_presence(self):
+        """A stream resolution drop can leave the region entirely outside the
+        new frame. The mapped region is degenerate — no motion evidence can be
+        read from it — and parked logic keeps presence."""
+        tracker = make_tracker()
+
+        # Enter on a 640x480 frame with the bird on the far right.
+        h, w = 480, 640
+        blob = (500, 200, 580, 280)
+        frame0 = np.zeros((h, w, 3), dtype=np.uint8)
+        frame0[200:280, 500:580] = 200
+        det = bird(0.8, blob, ts(0))
+        assert tracker.update(frame0, ts(0), [det], [det]) is True
+
+        # Stream drops to 320x240: same downscaled shape as the 640x480
+        # baseline, but the region (x ~ 480..600) is beyond the new width.
+        small = np.zeros((240, 320, 3), dtype=np.uint8)
+        assert tracker.update(small, ts(5), [], []) is True
+
+        info = tracker.state_info()
+        assert info["present"] is True
+        # No motion evidence was recorded from the degenerate region.
+        assert info["last_evidence_type"] == "detection"
+        assert info["last_evidence_time"] == ts(0).isoformat()
+
+    def test_overlap_guard_without_region_is_false(self):
+        """No region (absent): no bbox can overlap it."""
+        tracker = make_tracker()
+        assert tracker._overlaps_region((0, 0, 10, 10)) is False
+
+    def test_shift_guard_without_region_is_noop(self):
+        """Shifting toward a centroid with no region is a safe no-op."""
+        tracker = make_tracker()
+        tracker._shift_region_toward((50.0, 50.0), FRAME_W, FRAME_H)
+        assert tracker.state_info()["region"] is None

--- a/tests/test_visit_recorder.py
+++ b/tests/test_visit_recorder.py
@@ -1,12 +1,37 @@
 """Tests for visit recorder module."""
 
+import subprocess
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import numpy as np
+import pytest
 
 from kanyo.utils.visit_recorder import VisitRecorder
+
+
+def _make_recording_recorder(
+    tmp_path: Path,
+    fps: int = 30,
+    stream_recovery_threshold: int = 30,
+) -> tuple[VisitRecorder, MagicMock]:
+    """Build a recorder in a simulated recording state (no ffmpeg launched)."""
+    with patch(
+        "kanyo.utils.visit_recorder.detect_hardware_encoder",
+        return_value="libx264",
+    ):
+        recorder = VisitRecorder(
+            clips_dir=str(tmp_path),
+            fps=fps,
+            stream_recovery_threshold=stream_recovery_threshold,
+        )
+    mock_process = MagicMock()
+    mock_process.poll.return_value = None  # Still running
+    mock_process.stdin = MagicMock()
+    mock_process.stdin.fileno.return_value = 3
+    recorder._process = mock_process
+    return recorder, mock_process
 
 
 class TestVisitRecorderInit:
@@ -373,3 +398,456 @@ class TestVisitRecorderDetectionTracking:
             recorder.start_recording(datetime.now())
 
         assert recorder._last_detection_frame == 0
+
+
+class TestStreamOutageHandling:
+    """Tests for None-frame (stream outage) handling in write_frame."""
+
+    def test_stream_outage_exceeded_false_initially(self, tmp_path):
+        """Fresh recorder reports no outage."""
+        recorder, _ = _make_recording_recorder(tmp_path)
+        assert recorder.stream_outage_exceeded is False
+
+    def test_none_frame_without_freeze_frame_is_skipped(self, tmp_path):
+        """A None frame before any good frame is a no-op, not a failure."""
+        recorder, mock_process = _make_recording_recorder(tmp_path)
+
+        result = recorder.write_frame(None)
+
+        assert result is True
+        assert recorder._consecutive_none_frames == 1
+        mock_process.stdin.write.assert_not_called()
+
+    @patch("select.select", return_value=([], [3], []))
+    def test_none_frame_uses_freeze_frame(self, mock_select, tmp_path):
+        """During an outage the last good frame is written as a freeze frame."""
+        recorder, mock_process = _make_recording_recorder(tmp_path)
+        good_frame = np.full((4, 4, 3), 42, dtype=np.uint8)
+
+        assert recorder.write_frame(good_frame) is True
+        assert recorder.write_frame(None) is True
+
+        # Two writes: the good frame, then the freeze frame with the same bytes
+        assert mock_process.stdin.write.call_count == 2
+        first_bytes = mock_process.stdin.write.call_args_list[0][0][0]
+        second_bytes = mock_process.stdin.write.call_args_list[1][0][0]
+        assert first_bytes == second_bytes
+        assert recorder._frame_count == 2
+
+    def test_outage_exceeding_threshold_returns_false(self, tmp_path):
+        """An outage longer than the recovery threshold fails the write."""
+        recorder, _ = _make_recording_recorder(tmp_path, fps=1, stream_recovery_threshold=2)
+        # Threshold is 2s @ 1fps = 2 frames; third None frame exceeds it
+        assert recorder.write_frame(None) is True
+        assert recorder.write_frame(None) is True
+        assert recorder.write_frame(None) is False
+        assert recorder.stream_outage_exceeded is True
+
+    @patch("select.select", return_value=([], [3], []))
+    def test_stream_recovery_resets_outage_counter(self, mock_select, tmp_path):
+        """A good frame after an outage resets the None-frame counter."""
+        recorder, _ = _make_recording_recorder(tmp_path)
+        good_frame = np.zeros((4, 4, 3), dtype=np.uint8)
+
+        recorder.write_frame(good_frame)
+        recorder.write_frame(None)
+        assert recorder._consecutive_none_frames == 1
+
+        recorder.write_frame(good_frame)
+        assert recorder._consecutive_none_frames == 0
+        assert recorder.stream_outage_exceeded is False
+
+    @patch("select.select", return_value=([], [3], []))
+    def test_write_frame_infers_frame_size_when_unset(self, mock_select, tmp_path):
+        """write_frame derives frame size from the first frame if unknown."""
+        recorder, _ = _make_recording_recorder(tmp_path)
+        recorder._frame_size = None
+
+        frame = np.zeros((480, 640, 3), dtype=np.uint8)
+        assert recorder.write_frame(frame) is True
+        assert recorder._frame_size == (640, 480)
+
+
+class TestWriteRawFrameFailures:
+    """Tests for _write_raw_frame error paths."""
+
+    def test_no_process_returns_false(self, tmp_path):
+        """Without an ffmpeg process there is nothing to write to."""
+        recorder, _ = _make_recording_recorder(tmp_path)
+        recorder._process = None
+
+        frame = np.zeros((4, 4, 3), dtype=np.uint8)
+        assert recorder._write_raw_frame(frame) is False
+
+    def test_no_stdin_returns_false(self, tmp_path):
+        """A process without stdin cannot accept frames."""
+        recorder, mock_process = _make_recording_recorder(tmp_path)
+        mock_process.stdin = None
+
+        frame = np.zeros((4, 4, 3), dtype=np.uint8)
+        assert recorder._write_raw_frame(frame) is False
+
+    @patch("select.select", return_value=([], [], []))
+    def test_stdin_not_ready_drops_frame(self, mock_select, tmp_path):
+        """A stalled encoder (stdin not writable) drops the frame."""
+        recorder, mock_process = _make_recording_recorder(tmp_path)
+
+        frame = np.zeros((4, 4, 3), dtype=np.uint8)
+        assert recorder.write_frame(frame) is False
+        mock_process.stdin.write.assert_not_called()
+        assert recorder._frame_count == 0
+
+    @patch("select.select", return_value=([], [3], []))
+    def test_broken_pipe_returns_false(self, mock_select, tmp_path):
+        """A broken pipe (ffmpeg died) fails the write without raising."""
+        recorder, mock_process = _make_recording_recorder(tmp_path)
+        mock_process.stdin.write.side_effect = BrokenPipeError("pipe closed")
+
+        frame = np.zeros((4, 4, 3), dtype=np.uint8)
+        assert recorder.write_frame(frame) is False
+        assert recorder._frame_count == 0
+
+    @patch("select.select", return_value=([], [3], []))
+    def test_closed_stdin_value_error_returns_false(self, mock_select, tmp_path):
+        """A closed stdin (ValueError) fails the write without raising."""
+        recorder, mock_process = _make_recording_recorder(tmp_path)
+        mock_process.stdin.write.side_effect = ValueError("I/O operation on closed file")
+
+        frame = np.zeros((4, 4, 3), dtype=np.uint8)
+        assert recorder.write_frame(frame) is False
+
+
+class TestStartRecordingEncoderBranches:
+    """Tests for encoder-specific ffmpeg command construction."""
+
+    @pytest.mark.parametrize(
+        "encoder,expected_args",
+        [
+            ("h264_videotoolbox", ["h264_videotoolbox", "-q:v"]),
+            ("h264_vaapi", ["h264_vaapi", "-vaapi_device", "format=nv12,hwupload"]),
+            ("h264_nvenc", ["h264_nvenc", "-cq"]),
+            ("libx264", ["libx264", "-crf", "-preset"]),
+        ],
+    )
+    @patch("subprocess.Popen")
+    def test_encoder_command_options(self, mock_popen, encoder, expected_args, tmp_path):
+        """Each detected encoder produces its specific ffmpeg options."""
+        mock_process = MagicMock()
+        mock_process.poll.return_value = None
+        mock_popen.return_value = mock_process
+
+        with patch(
+            "kanyo.utils.visit_recorder.detect_hardware_encoder",
+            return_value=encoder,
+        ):
+            recorder = VisitRecorder(clips_dir=str(tmp_path))
+
+        recorder.start_recording(datetime(2024, 1, 15, 14, 30, 0))
+
+        cmd = mock_popen.call_args[0][0]
+        for arg in expected_args:
+            assert arg in cmd
+
+    @patch("subprocess.Popen")
+    def test_popen_failure_cleans_up_and_raises(self, mock_popen, tmp_path):
+        """A failure launching ffmpeg propagates after cleaning up state."""
+        mock_popen.side_effect = OSError("ffmpeg not found")
+
+        with patch(
+            "kanyo.utils.visit_recorder.detect_hardware_encoder",
+            return_value="libx264",
+        ):
+            recorder = VisitRecorder(clips_dir=str(tmp_path))
+
+        with pytest.raises(OSError):
+            recorder.start_recording(datetime(2024, 1, 15, 14, 30, 0))
+
+        assert recorder._process is None
+        assert recorder._stderr_file is None
+        assert recorder.is_recording is False
+
+    @patch("select.select", return_value=([], [3], []))
+    @patch("subprocess.Popen")
+    def test_lead_in_frames_written_on_start(self, mock_popen, mock_select, tmp_path):
+        """Buffered lead-in frames are decoded and written at recording start."""
+        mock_process = MagicMock()
+        mock_process.poll.return_value = None
+        mock_process.stdin = MagicMock()
+        mock_process.stdin.fileno.return_value = 3
+        mock_popen.return_value = mock_process
+
+        with patch(
+            "kanyo.utils.visit_recorder.detect_hardware_encoder",
+            return_value="libx264",
+        ):
+            recorder = VisitRecorder(clips_dir=str(tmp_path))
+
+        lead_in = []
+        for _ in range(3):
+            buffered = MagicMock()
+            buffered.decode.return_value = np.zeros((4, 4, 3), dtype=np.uint8)
+            lead_in.append(buffered)
+
+        recorder.start_recording(datetime(2024, 1, 15, 14, 30, 0), lead_in_frames=lead_in)
+
+        assert mock_process.stdin.write.call_count == 3
+        assert recorder._frame_count == 3
+        # Arrival event offset reflects the lead-in frames already written
+        assert recorder._events[0]["type"] == "arrival"
+        assert recorder._events[0]["offset_seconds"] == 3 / 30
+
+
+class TestStopRecordingEdgeCases:
+    """Tests for stop_recording error and cleanup paths."""
+
+    def test_stop_when_not_recording_returns_empty(self, tmp_path):
+        """Stopping an idle recorder is a safe no-op."""
+        with patch(
+            "kanyo.utils.visit_recorder.detect_hardware_encoder",
+            return_value="libx264",
+        ):
+            recorder = VisitRecorder(clips_dir=str(tmp_path))
+
+        path, metadata = recorder.stop_recording(datetime.now())
+
+        assert path is None
+        assert metadata == {}
+
+    @patch("subprocess.Popen")
+    def test_stop_kills_ffmpeg_on_timeout(self, mock_popen, tmp_path):
+        """An ffmpeg that won't finish is killed and cleanup still happens."""
+        mock_process = MagicMock()
+        mock_process.poll.return_value = None
+        mock_process.stdin = MagicMock()
+        mock_process.wait.side_effect = [
+            subprocess.TimeoutExpired(cmd="ffmpeg", timeout=30),
+            0,
+        ]
+        mock_popen.return_value = mock_process
+
+        with patch(
+            "kanyo.utils.visit_recorder.detect_hardware_encoder",
+            return_value="libx264",
+        ):
+            recorder = VisitRecorder(clips_dir=str(tmp_path))
+        recorder.start_recording(datetime(2024, 1, 15, 14, 30, 0))
+
+        path, metadata = recorder.stop_recording(datetime(2024, 1, 15, 15, 0, 0))
+
+        mock_process.kill.assert_called_once()
+        assert mock_process.wait.call_count == 2
+        assert recorder._stderr_file is None
+        assert path is not None
+        assert "events" in metadata
+
+    @patch("subprocess.Popen")
+    def test_stop_survives_close_error(self, mock_popen, tmp_path):
+        """An error while closing ffmpeg still produces metadata and cleanup."""
+        mock_process = MagicMock()
+        mock_process.poll.return_value = None
+        mock_process.stdin = MagicMock()
+        mock_process.stdin.close.side_effect = RuntimeError("close failed")
+        mock_popen.return_value = mock_process
+
+        with patch(
+            "kanyo.utils.visit_recorder.detect_hardware_encoder",
+            return_value="libx264",
+        ):
+            recorder = VisitRecorder(clips_dir=str(tmp_path))
+        recorder.start_recording(datetime(2024, 1, 15, 14, 30, 0))
+
+        path, metadata = recorder.stop_recording(datetime(2024, 1, 15, 15, 0, 0))
+
+        assert recorder._stderr_file is None
+        assert path is not None
+        assert metadata["duration_seconds"] == 1800.0
+
+    @patch("subprocess.Popen")
+    def test_confirmed_stop_survives_rename_failure(self, mock_popen, tmp_path):
+        """A failed .tmp → .mp4 rename is logged; the .tmp path is returned."""
+        mock_process = MagicMock()
+        mock_process.poll.return_value = None
+        mock_process.stdin = MagicMock()
+        mock_process.wait.return_value = 0
+        mock_popen.return_value = mock_process
+
+        with patch(
+            "kanyo.utils.visit_recorder.detect_hardware_encoder",
+            return_value="libx264",
+        ):
+            recorder = VisitRecorder(clips_dir=str(tmp_path))
+        recorder.start_recording(datetime(2024, 1, 15, 14, 30, 0))
+        tmp_file = recorder._visit_path
+        assert tmp_file is not None
+        tmp_file.write_bytes(b"fake mp4 data")
+        recorder.rename_to_final()  # confirm while recording
+
+        with patch.object(Path, "rename", side_effect=OSError("permission denied")):
+            path, metadata = recorder.stop_recording(datetime(2024, 1, 15, 15, 0, 0))
+
+        # Rename failed, so the .tmp file survives and metadata points at it
+        assert path == tmp_file
+        assert metadata["visit_file"].endswith(".tmp")
+        assert tmp_file.exists()
+
+    @patch("subprocess.Popen")
+    def test_confirmed_stop_survives_log_unlink_failure(self, mock_popen, tmp_path):
+        """A failed ffmpeg-log deletion does not break stop_recording."""
+        mock_process = MagicMock()
+        mock_process.poll.return_value = None
+        mock_process.stdin = MagicMock()
+        mock_process.wait.return_value = 0
+        mock_popen.return_value = mock_process
+
+        with patch(
+            "kanyo.utils.visit_recorder.detect_hardware_encoder",
+            return_value="libx264",
+        ):
+            recorder = VisitRecorder(clips_dir=str(tmp_path))
+        recorder.start_recording(datetime(2024, 1, 15, 14, 30, 0))
+        tmp_file = recorder._visit_path
+        final_file = recorder._final_path
+        assert tmp_file is not None and final_file is not None
+        tmp_file.write_bytes(b"fake mp4 data")
+        # Log file at the post-rename path so the deletion branch runs
+        final_file.with_suffix(".ffmpeg.log").write_text("ffmpeg output")
+        recorder.rename_to_final()
+
+        with patch.object(Path, "unlink", side_effect=OSError("busy")):
+            path, metadata = recorder.stop_recording(datetime(2024, 1, 15, 15, 0, 0))
+
+        assert path == final_file
+        assert metadata["visit_file"] == str(final_file)
+
+
+class TestExtractClipDelegation:
+    """Tests for the instance extract_clip delegating to the static method."""
+
+    @patch("subprocess.run")
+    def test_extract_clip_delegates_when_visit_file_exists(self, mock_run, tmp_path):
+        """With a visit file on disk, extraction runs against it."""
+        mock_run.return_value = MagicMock(returncode=0)
+
+        with patch(
+            "kanyo.utils.visit_recorder.detect_hardware_encoder",
+            return_value="libx264",
+        ):
+            recorder = VisitRecorder(clips_dir=str(tmp_path))
+        visit_file = tmp_path / "visit.mp4"
+        visit_file.write_bytes(b"fake mp4 data")
+        recorder._visit_path = visit_file
+
+        result = recorder.extract_clip(
+            start_offset=2.0,
+            duration=4.0,
+            output_path=tmp_path / "clip.mp4",
+        )
+
+        assert result is True
+        cmd = mock_run.call_args[0][0]
+        assert str(visit_file) in cmd
+
+
+class TestExtractClipFromFileErrorPaths:
+    """Tests for extract_clip_from_file error handling."""
+
+    @patch("subprocess.run")
+    def test_log_unlink_failure_still_succeeds(self, mock_run, tmp_path):
+        """A leftover ffmpeg log that can't be deleted doesn't fail extraction."""
+        mock_run.return_value = MagicMock(returncode=0)
+
+        visit_file = tmp_path / "visit.mp4"
+        visit_file.write_bytes(b"fake mp4 data")
+        output_path = tmp_path / "clip.mp4"
+
+        with patch.object(Path, "unlink", side_effect=OSError("busy")):
+            result = VisitRecorder.extract_clip_from_file(
+                visit_file,
+                start_offset=1.0,
+                duration=2.0,
+                output_path=output_path,
+            )
+
+        assert result is True
+
+    @patch("subprocess.run")
+    def test_subprocess_exception_returns_false(self, mock_run, tmp_path):
+        """A hung ffmpeg (TimeoutExpired) is caught and reported as failure."""
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="ffmpeg", timeout=60)
+
+        visit_file = tmp_path / "visit.mp4"
+        visit_file.write_bytes(b"fake mp4 data")
+
+        result = VisitRecorder.extract_clip_from_file(
+            visit_file,
+            start_offset=1.0,
+            duration=2.0,
+            output_path=tmp_path / "clip.mp4",
+        )
+
+        assert result is False
+
+
+class TestRenameToFinalImmediate:
+    """Tests for rename_to_final when not recording (immediate rename)."""
+
+    def test_immediate_rename_success(self, tmp_path):
+        """When idle, rename_to_final renames .tmp to .mp4 on the spot."""
+        with patch(
+            "kanyo.utils.visit_recorder.detect_hardware_encoder",
+            return_value="libx264",
+        ):
+            recorder = VisitRecorder(clips_dir=str(tmp_path))
+        tmp_file = tmp_path / "visit.mp4.tmp"
+        tmp_file.write_bytes(b"fake mp4 data")
+        final_file = tmp_path / "visit.mp4"
+        recorder._visit_path = tmp_file
+        recorder._final_path = final_file
+
+        result = recorder.rename_to_final()
+
+        assert result == final_file
+        assert final_file.exists()
+        assert not tmp_file.exists()
+        assert recorder._visit_path == final_file
+
+
+class TestGetTempPath:
+    """Tests for get_temp_path."""
+
+    def test_returns_tmp_path_while_unconfirmed(self, tmp_path):
+        """A .tmp visit path is exposed for deletion of cancelled recordings."""
+        with patch(
+            "kanyo.utils.visit_recorder.detect_hardware_encoder",
+            return_value="libx264",
+        ):
+            recorder = VisitRecorder(clips_dir=str(tmp_path))
+        assert recorder.get_temp_path() is None  # no visit path yet
+
+        recorder._visit_path = tmp_path / "visit.mp4.tmp"
+        assert recorder.get_temp_path() == recorder._visit_path
+
+        recorder._visit_path = tmp_path / "visit.mp4"  # finalized
+        assert recorder.get_temp_path() is None
+
+
+class TestRenameToFinalErrorPath:
+    """Tests for rename_to_final immediate-rename failure."""
+
+    def test_immediate_rename_failure_returns_none(self, tmp_path):
+        """A failed immediate rename returns None and leaves the .tmp path."""
+        with patch(
+            "kanyo.utils.visit_recorder.detect_hardware_encoder",
+            return_value="libx264",
+        ):
+            recorder = VisitRecorder(clips_dir=str(tmp_path))
+        tmp_file = tmp_path / "visit.mp4.tmp"
+        tmp_file.write_bytes(b"fake mp4 data")
+        recorder._visit_path = tmp_file
+        recorder._final_path = tmp_path / "visit.mp4"
+
+        with patch.object(Path, "rename", side_effect=OSError("permission denied")):
+            result = recorder.rename_to_final()
+
+        assert result is None
+        assert recorder._visit_path == tmp_file


### PR DESCRIPTION
## What

- Fixes the 4 pre-existing test failures:
  - `test_log_service.py` TestShowContext (3): tests hardcoded a January date and filtered with `since=24h`, so they failed on any later date. Tests now generate timestamps relative to now (UTC); the service code was correct.
  - `test_detection.py::test_detect_on_blank_frame`: required real YOLO weights; now uses a mocked model like the newer detect tests.
- Adds 235 behavior-specification tests bringing every `src/kanyo` module to 100% line coverage (TOTAL 78% -> 100%, 720 tests passing). All subprocess/ffmpeg, cv2, model-loading, and network boundaries are mocked; no hardware probing runs under pytest.
- Adds `[tool.coverage.report]` to `pyproject.toml`: `fail_under = 95` (enforced on every pytest run via the existing `--cov` addopts) plus `exclude_also` for `TYPE_CHECKING` imports and `__main__` CLI blocks. No `pragma: no cover` anywhere.

## Notable findings (not fixed here, candidates for follow-up hos)

- `visit_recorder.stop_recording` computes the ffmpeg-log path with `with_suffix(".ffmpeg.log")`, which never matches the actual `.mp4.ffmpeg.log` file, so stderr logs are never cleaned up on confirmed stops.
- `generation/clips.py` line 192 gates `last_event_time_secs` on the original event type instead of the final (merged) type, so merged clips never get the intended enter+exit thumbnail pair.
- `buffer_monitor._handle_event`'s defensive string-timestamp parsing is only partially safe: a plain-str `visit_start` reaching `FalconVisit` would still raise on `strftime`.

## Verification

- Full suite: 720 passed, 0 failed
- Coverage: TOTAL 100%, gate `--cov-fail-under=95` green
- `mypy src/` clean; black + isort clean on all touched files