### PR TITLE
Move detector deployment to pinned images; kanyo v1.0.0 deploy plan

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,11 +40,14 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # Semver tags are flavor-suffixed (1.0.0-cpu / 1.0.0-nvidia) so a
+          # version tag is never ambiguous about hardware flavor. Production
+          # pins the -nvidia flavor (see docker/DOCKER-DEPLOYMENT.md).
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{version}},suffix=-cpu
+            type=semver,pattern={{major}}.{{minor}},suffix=-cpu
             type=raw,value=cpu,enable={{is_default_branch}}
             type=sha,prefix=cpu-
 
@@ -86,6 +89,8 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
+            type=semver,pattern={{version}},suffix=-nvidia
+            type=semver,pattern={{major}}.{{minor}},suffix=-nvidia
             type=raw,value=nvidia,enable={{is_default_branch}}
             type=sha,prefix=nvidia-
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,10 @@ config.yaml
 /Agent-Tasks/
 devlog/Agent-Tasks/
 
-# Docker - user-specific production config
+# Docker - user-specific production config (host copies stay untracked)
 docker-compose.yml
+# ...but the canonical production template IS tracked:
+!docker/docker-compose.yml
 
 # Data - production configs and outputs
 data/

--- a/README.md
+++ b/README.md
@@ -204,6 +204,12 @@ Issues and pull requests are welcome. If you're interested in:
 
 ---
 
+## Versioning
+
+v1.0.0 is the first stable release. From v1.0.0 onward the project follows [semantic versioning](https://semver.org/): releases are cut as `v*` git tags, and CI publishes matching Docker image tags to GHCR (flavor-suffixed, e.g. `1.0.0-nvidia`, `1.0.0-cpu`). Production deployments pin a release image tag; see [docker/DOCKER-DEPLOYMENT.md](docker/DOCKER-DEPLOYMENT.md).
+
+---
+
 ## License
 
 MIT

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,5 +1,13 @@
 # Kanyo Environment Variables
-# Copy this file to .env and fill in your values
+# Copy this file to .env (next to docker-compose.yml) and fill in your values
+
+# ──────────────────────────────────────────────────────────────
+# Detector Image (image-based deployment)
+# ──────────────────────────────────────────────────────────────
+# Pinned release image the detector fleet runs. Semver tags are
+# flavor-suffixed: <version>-nvidia (production) or <version>-cpu.
+# Upgrade/rollback = repoint this and `docker compose up -d --force-recreate`.
+KANYO_IMAGE=ghcr.io/sageframe-no-kaji/kanyo-contemplating-falcons-dev:1.0.0-nvidia
 
 # ──────────────────────────────────────────────────────────────
 # Notification Secrets (REQUIRED if telegram_enabled: true)
@@ -13,8 +21,13 @@ TELEGRAM_BOT_TOKEN=your_bot_token_here
 # Where to store clips, logs, and config for each camera stream
 KANYO_CAM1_ROOT=/opt/services/kanyo-harvard
 KANYO_CAM2_ROOT=/opt/services/kanyo-nsw
+KANYO_CAM4_ROOT=/opt/services/kanyo-fortwayne
+KANYO_CAM5_ROOT=/opt/services/kanyo-umass
+KANYO_CAM6_ROOT=/opt/services/kanyo-bigbear
 
-# Where the kanyo source code is checked out (for volume mounts)
+# Where the kanyo source code is checked out on the host.
+# Used for the admin dashboard build and the shared cookies.txt —
+# NOT mounted as detector source (that is a dev-only override).
 KANYO_CODE_ROOT=/opt/services/kanyo-code
 
 # Admin GUI authentication
@@ -25,5 +38,5 @@ ADMIN_PASSWORD=change-this-password
 # Notes
 # ──────────────────────────────────────────────────────────────
 # - Stream-specific settings (channel, video source) go in config.yaml
-# - This file contains secrets and Docker path mappings only
+# - This file contains secrets, the image pin, and Docker path mappings only
 # - One .env works for multiple camera streams

--- a/docker/DOCKER-DEPLOYMENT.md
+++ b/docker/DOCKER-DEPLOYMENT.md
@@ -1,395 +1,199 @@
 # Kanyo Docker Deployment Guide
 
-This guide covers deploying Kanyo with Docker, from single-stream to multi-stream production setups.
+How Kanyo deploys with Docker. **The deployment path is image-based**: detectors
+run a pinned, semver-tagged image pulled from GHCR. The legacy source-mount
+route is a development-only option, documented at the end.
+
+For the full production deploy plan for kanyo.lan, see
+[docs/deployment-kanyo.md](../docs/deployment-kanyo.md).
 
 ---
 
-## Quick Start (Single Stream)
+## Images and Tags
 
-### Prerequisites
+CI ([.github/workflows/build.yml](../.github/workflows/build.yml)) builds and
+publishes to `ghcr.io/sageframe-no-kaji/kanyo-contemplating-falcons-dev` on
+every push to `main` and on every `v*` git tag.
 
-- Docker and Docker Compose
-- NVIDIA GPU with drivers (or see [CPU/Intel variants](#hardware-variants))
-- NVIDIA Container Toolkit installed
+| Tag | Built from | Meaning |
+|-----|-----------|---------|
+| `1.0.0-nvidia`, `1.0-nvidia` | `Dockerfile.nvidia` | Pinned release, NVIDIA GPU flavor — **what production runs** |
+| `1.0.0-cpu`, `1.0-cpu` | `Dockerfile.cpu` | Pinned release, CPU flavor |
+| `nvidia`, `cpu` | respective Dockerfile | Floating tip of `main` — do not pin production to these |
+| `nvidia-<sha>`, `cpu-<sha>` | respective Dockerfile | Exact-commit builds, for forensic pinning |
 
-### Step 1: Create Deployment Directory
+Semver tags are always flavor-suffixed; there is no bare `:1.0.0` tag, so a
+version tag can never be ambiguous about hardware flavor.
+
+Model weights (`yolov8n`) are baked into the image at build time; `/app/models`
+is not mounted. A model change is an image change and ships as a new version.
+
+The `vaapi` (Intel iGPU) flavor exists as `Dockerfile.vaapi` but is not built
+by CI; build it locally with `ops/build/build-vaapi.sh` if needed.
+
+---
+
+## Production Deployment (image-based)
+
+### Layout
+
+One compose project drives the whole fleet:
+
+```
+/opt/services/
+├── kanyo-admin/               ← compose project (docker-compose.yml + .env)
+├── kanyo-code/                ← host checkout: admin build source, cookies.txt, ops
+├── kanyo-harvard/             ← per-site: config.yaml, clips/, logs/
+├── kanyo-nsw/
+├── kanyo-fortwayne/
+├── kanyo-umass/
+└── kanyo-bigbear/             ← defined in compose, not normally running
+```
+
+The canonical compose template is [docker/docker-compose.yml](docker-compose.yml)
+in this repo; the live copy at `/opt/services/kanyo-admin/docker-compose.yml`
+is a gitignored host copy of it. Edit in the repo, copy to the host.
+
+The image is selected by `KANYO_IMAGE` in `/opt/services/kanyo-admin/.env`:
 
 ```bash
-mkdir -p /opt/services/kanyo-mystream
-cd /opt/services/kanyo-mystream
+KANYO_IMAGE=ghcr.io/sageframe-no-kaji/kanyo-contemplating-falcons-dev:1.0.0-nvidia
+TELEGRAM_BOT_TOKEN=...
+KANYO_CODE_ROOT=/opt/services/kanyo-code
+KANYO_CAM1_ROOT=/opt/services/kanyo-harvard
+KANYO_CAM2_ROOT=/opt/services/kanyo-nsw
+KANYO_CAM4_ROOT=/opt/services/kanyo-fortwayne
+KANYO_CAM5_ROOT=/opt/services/kanyo-umass
+KANYO_CAM6_ROOT=/opt/services/kanyo-bigbear
 ```
 
-### Step 2: Get Docker Compose File
+### Upgrade
+
+Releases are cut by pushing a git tag (`git tag v1.1.0 && git push origin v1.1.0`);
+CI publishes `1.1.0-nvidia` / `1.1.0-cpu`. Then, from the Mac:
 
 ```bash
-curl -O https://raw.githubusercontent.com/sageframe-no-kaji/kanyo-contemplating-falcons-dev/main/docker/docker-compose.yml
+./ops/update-code.sh 1.1.0-nvidia          # canary harvard, confirm, then fleet
 ```
 
-### Step 3: Create Configuration
+Or manually on the host:
 
 ```bash
-curl -O https://raw.githubusercontent.com/sageframe-no-kaji/kanyo-contemplating-falcons-dev/main/configs/config.template.yaml
-mv config.template.yaml config.yaml
+cd /opt/services/kanyo-admin
+sed -i 's|^KANYO_IMAGE=.*|KANYO_IMAGE=ghcr.io/sageframe-no-kaji/kanyo-contemplating-falcons-dev:1.1.0-nvidia|' .env
+sudo docker compose pull harvard-gpu
+sudo docker compose up -d --force-recreate harvard-gpu     # canary
+# verify logs (see deploy plan), then:
+sudo docker compose pull && sudo docker compose up -d --force-recreate
 ```
 
-Edit `config.yaml`:
-```yaml
-video_source: "https://www.youtube.com/watch?v=YOUR_VIDEO_ID"
-timezone: "America/New_York"
-stream_name: "My Falcon Cam"
-telegram_enabled: false  # Set to true after configuring Telegram
-```
+`--force-recreate` matters: `restart` does not pick up a new image.
 
-### Step 4: Create Directories and Environment
+### Rollback
+
+Rollback is the same move with the previous tag — repoint and recreate:
 
 ```bash
-mkdir -p clips logs
-
-# If using Telegram notifications:
-echo "TELEGRAM_BOT_TOKEN=your_token_here" > .env
+sed -i 's|^KANYO_IMAGE=.*|KANYO_IMAGE=ghcr.io/sageframe-no-kaji/kanyo-contemplating-falcons-dev:1.0.0-nvidia|' .env
+sudo docker compose up -d --force-recreate
 ```
 
-### Step 5: Start
+Previously-pulled images are still on the host, so rollback needs no pull and
+completes in seconds.
+
+### Admin dashboard (host-built, unchanged)
+
+The dashboard is the one service still built on the host, from
+`${KANYO_CODE_ROOT}/admin/web`. Update it with:
 
 ```bash
-docker compose up -d
+./ops/update-admin.sh          # git pull kanyo-code + rebuild dashboard
 ```
 
-### Step 6: Verify
+The `kanyo-code` checkout stays on the host for three reasons: it is the admin
+dashboard build source, it holds the shared `cookies.txt`, and it carries the
+`ops/` scripts. It is **not** mounted into the detector containers.
 
-```bash
-docker logs kanyo-detection --tail 50 -f
-```
+---
 
-You should see:
-```
-INFO | ✅ Connected to stream
-INFO | Frame 100: bird detected (confidence: 0.67)
-```
+## Configuration
+
+Each site mounts a single `config.yaml` read-only from its site directory.
+All keys are documented in
+[configs/config.template.yaml](../configs/config.template.yaml) — that file is
+the config-key reference; this guide does not duplicate it.
+
+Config changes do not require a new image: edit
+`/opt/services/kanyo-<site>/config.yaml` and `docker compose restart <site>-gpu`.
 
 ---
 
 ## Hardware Variants
 
-Three Docker images are available:
+| Flavor | Hardware | Dockerfile |
+|--------|----------|------------|
+| `nvidia` | NVIDIA GPU | `Dockerfile.nvidia` — production |
+| `cpu` | Any CPU | `Dockerfile.cpu` |
+| `vaapi` | Intel iGPU | `Dockerfile.vaapi` — not CI-built |
 
-| Image Tag | Hardware | Use Case |
-|-----------|----------|----------|
-| `:nvidia` | NVIDIA GPU | Fastest, recommended |
-| `:vaapi` | Intel iGPU | Good for Intel systems |
-| `:cpu` | CPU only | Works anywhere, slower |
-
-To use a different variant, change the image in `docker-compose.yml`:
-
-```yaml
-x-kanyo-gpu-service: &kanyo-gpu-service
-  image: ghcr.io/sageframe-no-kaji/kanyo-contemplating-falcons-dev:vaapi  # or :cpu
-```
-
-For Intel iGPU, also remove the NVIDIA `deploy` section and add device access:
+For CPU-only, remove the `deploy.resources.reservations` block from the
+compose anchor. For VAAPI, additionally add:
 
 ```yaml
-x-kanyo-service: &kanyo-service
-  image: ghcr.io/sageframe-no-kaji/kanyo-contemplating-falcons-dev:vaapi
-  devices:
-    - /dev/dri:/dev/dri
-  # ... rest of config (no deploy.resources.reservations)
+devices:
+  - /dev/dri:/dev/dri
 ```
-
-For CPU-only, remove the entire `deploy` section.
-
----
-
-## Multi-Stream Deployment
-
-For monitoring multiple camera streams, use the YAML anchor pattern.
-
-### Directory Structure
-
-```
-/opt/services/
-├── kanyo-admin/              # Docker Compose, .env
-│   ├── docker-compose.yml
-│   └── .env
-├── kanyo-harvard/            # Stream 1
-│   ├── config.yaml
-│   ├── clips/
-│   └── logs/
-├── kanyo-nsw/                # Stream 2
-│   ├── config.yaml
-│   ├── clips/
-│   └── logs/
-└── kanyo-code/               # Source code (for development)
-    └── src/
-```
-
-### Multi-Stream docker-compose.yml
-
-```yaml
-x-kanyo-gpu-service: &kanyo-gpu-service
-  image: ghcr.io/sageframe-no-kaji/kanyo-contemplating-falcons-dev:nvidia
-  pull_policy: if_not_present
-  env_file: .env
-  shm_size: '2gb'
-  environment:
-    - PYTHONUNBUFFERED=1
-    - MALLOC_ARENA_MAX=2
-  deploy:
-    resources:
-      reservations:
-        devices:
-          - driver: nvidia
-            count: 1
-            capabilities: [gpu]
-  restart: unless-stopped
-  logging:
-    driver: "json-file"
-    options:
-      max-size: "10m"
-      max-file: "3"
-
-services:
-  harvard-gpu:
-    <<: *kanyo-gpu-service
-    container_name: kanyo-harvard-gpu
-    command: ["/bin/sh", "-c", "umask 027 && exec python -m kanyo.detection.buffer_monitor"]
-    volumes:
-      - ${KANYO_CAM1_ROOT}/config.yaml:/app/config.yaml:ro
-      - ${KANYO_CAM1_ROOT}/clips:/app/clips
-      - ${KANYO_CAM1_ROOT}/logs:/app/logs
-
-  nsw-gpu:
-    <<: *kanyo-gpu-service
-    container_name: kanyo-nsw-gpu
-    command: ["/bin/sh", "-c", "umask 027 && exec python -m kanyo.detection.buffer_monitor"]
-    volumes:
-      - ${KANYO_CAM2_ROOT}/config.yaml:/app/config.yaml:ro
-      - ${KANYO_CAM2_ROOT}/clips:/app/clips
-      - ${KANYO_CAM2_ROOT}/logs:/app/logs
-```
-
-### Environment File (.env)
-
-```bash
-TELEGRAM_BOT_TOKEN=your_bot_token_here
-KANYO_CAM1_ROOT=/opt/services/kanyo-harvard
-KANYO_CAM2_ROOT=/opt/services/kanyo-nsw
-```
-
-### Adding a New Stream
-
-1. Create stream directory:
-   ```bash
-   mkdir -p /opt/services/kanyo-newstream/{clips,logs}
-   ```
-
-2. Create `config.yaml` for the stream
-
-3. Add to `.env`:
-   ```bash
-   KANYO_CAM3_ROOT=/opt/services/kanyo-newstream
-   ```
-
-4. Add service to `docker-compose.yml`:
-   ```yaml
-   newstream-gpu:
-     <<: *kanyo-gpu-service
-     container_name: kanyo-newstream-gpu
-     command: ["/bin/sh", "-c", "umask 027 && exec python -m kanyo.detection.buffer_monitor"]
-     volumes:
-       - ${KANYO_CAM3_ROOT}/config.yaml:/app/config.yaml:ro
-       - ${KANYO_CAM3_ROOT}/clips:/app/clips
-       - ${KANYO_CAM3_ROOT}/logs:/app/logs
-   ```
-
-5. Start:
-   ```bash
-   docker compose up -d newstream-gpu
-   ```
-
----
-
-## Development Workflow
-
-For rapid iteration during development, mount source code from the host instead of using the code baked into the image.
-
-### Setup
-
-1. Clone the repository:
-   ```bash
-   git clone https://github.com/sageframe-no-kaji/kanyo-contemplating-falcons-dev.git /opt/services/kanyo-code
-   ```
-
-2. Add code volume to your services:
-   ```yaml
-   services:
-     harvard-gpu:
-       <<: *kanyo-gpu-service
-       volumes:
-         - /opt/services/kanyo-code/src:/app/src:ro    # ADD THIS
-         - ${KANYO_CAM1_ROOT}/config.yaml:/app/config.yaml:ro
-         - ${KANYO_CAM1_ROOT}/clips:/app/clips
-         - ${KANYO_CAM1_ROOT}/logs:/app/logs
-   ```
-
-### Update Cycle
-
-With volume-mounted code, updates are instant:
-
-```bash
-# On your development machine
-git add -A && git commit -m "Fix bug" && git push
-
-# On the server
-cd /opt/services/kanyo-code && git pull
-cd /opt/services/kanyo-admin && docker compose restart
-```
-
-Total time: ~10 seconds vs ~45 minutes for image rebuilds.
-
-### When to Rebuild Images
-
-Only rebuild images when:
-- `requirements.txt` changes
-- Dockerfile changes
-- Creating a production release
-
-```bash
-# Rebuild locally
-docker build -f docker/Dockerfile.nvidia -t kanyo:nvidia .
-
-# Or pull updated image
-docker compose pull
-```
-
----
-
-## ZFS Storage (Optional)
-
-For production deployments, ZFS provides snapshots, compression, and quotas.
-
-### Create Datasets
-
-```bash
-# Parent dataset
-sudo zfs create rpool/kanyo
-
-# Per-stream datasets
-sudo zfs create rpool/kanyo/harvard
-sudo zfs create rpool/kanyo/nsw
-
-# Set quotas (optional)
-sudo zfs set quota=500G rpool/kanyo/harvard
-sudo zfs set quota=500G rpool/kanyo/nsw
-
-# Enable compression
-sudo zfs set compression=lz4 rpool/kanyo
-```
-
-### Snapshots
-
-```bash
-# Manual snapshot
-sudo zfs snapshot -r rpool/kanyo@backup-$(date +%Y%m%d)
-
-# Automated daily snapshots (add to crontab)
-0 2 * * * /usr/sbin/zfs snapshot -r rpool/kanyo@daily-$(date +\%Y\%m\%d)
-
-# Keep last 7 days
-0 3 * * * /usr/sbin/zfs list -t snapshot -o name | grep 'daily' | head -n -7 | xargs -n1 /usr/sbin/zfs destroy
-```
-
-### Restore
-
-```bash
-# List snapshots
-zfs list -t snapshot | grep kanyo
-
-# Rollback (destructive)
-sudo zfs rollback rpool/kanyo/harvard@daily-20260123
-
-# Or restore specific files
-cp /opt/services/kanyo-harvard/.zfs/snapshot/daily-20260123/clips/2026-01-22/* \
-   /opt/services/kanyo-harvard/clips/2026-01-22/
-```
-
----
-
-## Admin Dashboard (Optional)
-
-The admin dashboard provides a web UI for managing streams.
-
-Add to `docker-compose.yml`:
-
-```yaml
-services:
-  # ... detection services ...
-
-  dashboard:
-    build: /opt/services/kanyo-code/admin/web
-    container_name: kanyo-admin-web
-    ports:
-      - "5000:5000"
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-      - ${KANYO_CAM1_ROOT}:/data/harvard
-      - ${KANYO_CAM2_ROOT}:/data/nsw
-    restart: unless-stopped
-```
-
-Access at `http://your-server:5000`
 
 ---
 
 ## Operations
 
-### Common Commands
-
 ```bash
-# Start all
-docker compose up -d
+cd /opt/services/kanyo-admin
 
-# Stop all
-docker compose down
-
-# Restart specific stream
-docker compose restart harvard-gpu
-
-# View logs
-docker logs kanyo-harvard-gpu --tail 100 -f
-
-# View all container status
-docker compose ps
-
-# Resource usage
-docker stats
+sudo docker compose ps                          # fleet status
+sudo docker compose up -d                       # start all
+sudo docker compose restart harvard-gpu         # restart one site (same image)
+sudo docker logs kanyo-harvard-gpu --tail 100 -f
+docker image inspect --format '{{index .RepoTags}}' \
+  $(docker inspect --format '{{.Image}}' kanyo-harvard-gpu)   # what's running?
 ```
 
-### Health Checks
+Health checks:
 
 ```bash
-# Check containers running
-docker compose ps
-
-# Check recent clips
-ls -la /opt/services/kanyo-harvard/clips/$(date +%Y-%m-%d)/
-
-# Check disk usage
-du -sh /opt/services/kanyo-*/clips/
-
-# Check ZFS (if using)
-zfs list | grep kanyo
+sudo docker compose ps                                        # everything Up?
+ls -la /opt/services/kanyo-harvard/clips/$(date +%Y-%m-%d)/   # clips flowing?
+du -sh /opt/services/kanyo-*/clips/                           # disk
+curl -s -o /dev/null -w '%{http_code}\n' http://localhost:5000/   # admin up?
 ```
 
-### Maintenance
+---
+
+## Development Workflow (dev-only route)
+
+For rapid iteration on a **development** host, the legacy source-mount route is
+still available: mount `src/` from a checkout over the baked image code, then
+`git pull` + `docker compose restart` picks up changes in ~10 seconds.
+
+The exact override block is documented (commented out) at the bottom of
+[docker-compose.yml](docker-compose.yml). Enable it per-service by adding:
+
+```yaml
+volumes:
+  - ${KANYO_CODE_ROOT}/src:/app/src:ro     # DEV ONLY
+```
+
+Do not run production this way. With a src mount, the image tag no longer
+tells you what code is running, upgrades and rollbacks stop being atomic, and
+a host-side `git pull` can silently change production behavior. Production
+moved to pinned images at v1.0.0 precisely to close that gap.
+
+When developing, rebuild the image (rather than mounting) when any of these
+change: `requirements*.txt`, the Dockerfiles, or the model download step.
 
 ```bash
-# Delete clips older than 30 days
-find /opt/services/kanyo-*/clips/ -name "*.mp4" -mtime +30 -delete
-find /opt/services/kanyo-*/clips/ -name "*.jpg" -mtime +30 -delete
-
-# Prune Docker resources
-docker system prune -f
+docker build -f docker/Dockerfile.nvidia -t kanyo:nvidia-dev .
 ```
 
 ---
@@ -399,44 +203,31 @@ docker system prune -f
 ### Container won't start
 
 ```bash
-docker logs kanyo-detection --tail 100
+sudo docker logs kanyo-<site>-gpu --tail 100
 ```
 
-Common issues:
-- **"No such file or directory"** — Check volume paths exist
-- **"Permission denied"** — Run `sudo chown -R 1000:1000 /opt/services/kanyo-*`
-- **"NVIDIA driver"** — Install NVIDIA Container Toolkit
+- **"No such file or directory"** — a volume path in `.env` doesn't exist on the host
+- **"Permission denied"** — site dirs must be owned `1000:1000` (`sudo chown -R 1000:1000 /opt/services/kanyo-<site>`)
+- **"could not select device driver nvidia"** — NVIDIA Container Toolkit missing/broken; verify with `docker run --rm --gpus all nvidia/cuda:12.1.0-base-ubuntu22.04 nvidia-smi`
 
 ### YouTube stream fails
 
-```bash
-# Rebuild with latest yt-dlp
-docker compose build --no-cache
-docker compose up -d
-```
+yt-dlp is upgraded at image build time. If YouTube changes break stream capture,
+a floating-tip image (`:nvidia`) or a new release usually carries the fixed
+yt-dlp. Persistent 403s across all streams usually mean an IP ban — see
+`ops/ban-watch.sh`.
 
 ### High memory usage
 
-The `shm_size: '2gb'` setting is important for YOLO. If you see OOM errors:
-
-```yaml
-shm_size: '4gb'  # Increase shared memory
-```
-
-### GPU not detected
-
-```bash
-# Verify NVIDIA runtime
-docker run --rm --gpus all nvidia/cuda:12.1-base nvidia-smi
-
-# If that fails, install NVIDIA Container Toolkit:
-# https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html
-```
+`shm_size: '2gb'` is required for YOLO. If you see OOM errors, raise it to
+`'4gb'` in the anchor.
 
 ---
 
 ## See Also
 
-- [QUICKSTART.md](../QUICKSTART.md) — Quick setup guide
-- [docs/adding-streams.md](../docs/adding-streams.md) — Detailed stream configuration
-- [docs/sensing-logic.md](../docs/sensing-logic.md) — How detection works
+- [docs/deployment-kanyo.md](../docs/deployment-kanyo.md) — production deploy plan (kanyo.lan)
+- [docs/docker-architecture.md](../docs/docker-architecture.md) — what runs where on the host
+- [docs/adding-streams.md](../docs/adding-streams.md) — adding a stream
+- [configs/config.template.yaml](../configs/config.template.yaml) — config-key reference
+- [Quickstart.md](../Quickstart.md) — single-stream quick start

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,165 @@
+# Kanyo Docker Compose — production template (NVIDIA GPU)
+#
+# This is the canonical template for the production host (kanyo.lan). The live
+# copy runs at /opt/services/kanyo-admin/docker-compose.yml (gitignored host
+# copy). Keep the two in sync: edit here, then copy to the host.
+#
+# Deployment model: IMAGE-BASED. Detectors run a pinned semver image pulled
+# from GHCR (built by CI on git tag push). No source code is mounted into the
+# detector containers — the code baked into the image is what runs.
+# See docker/DOCKER-DEPLOYMENT.md for the deployment guide and
+# docs/deployment-kanyo.md for the production deploy plan.
+#
+# Image tags are flavor-suffixed: <version>-nvidia (production), <version>-cpu.
+# Pin via KANYO_IMAGE in .env; the default below is the fallback.
+#
+# Prerequisites:
+#   - Docker with NVIDIA Container Toolkit (GPU drivers installed)
+#   - .env file providing:
+#       TELEGRAM_BOT_TOKEN   (if notifications enabled)
+#       KANYO_IMAGE          (pinned image, e.g. ...:1.0.0-nvidia)
+#       KANYO_CODE_ROOT      (host checkout, e.g. /opt/services/kanyo-code)
+#       KANYO_CAM1_ROOT      (/opt/services/kanyo-harvard)
+#       KANYO_CAM2_ROOT      (/opt/services/kanyo-nsw)
+#       KANYO_CAM4_ROOT      (/opt/services/kanyo-fortwayne)
+#       KANYO_CAM5_ROOT      (/opt/services/kanyo-umass)
+#       KANYO_CAM6_ROOT      (/opt/services/kanyo-bigbear)
+#   - Per-site directories: <root>/config.yaml, <root>/clips/, <root>/logs/
+#   - Shared YouTube cookies at ${KANYO_CODE_ROOT}/cookies.txt (mounted rw so
+#     yt-dlp can refresh rotating cookie values)
+#
+# For CPU-only or Intel iGPU hosts, see Dockerfile.cpu / Dockerfile.vaapi and
+# the Hardware Variants section of DOCKER-DEPLOYMENT.md.
+
+# =============================================================================
+# YAML anchor — base detector service definition
+# =============================================================================
+x-kanyo-gpu-service: &kanyo-gpu-service
+  image: ${KANYO_IMAGE:-ghcr.io/sageframe-no-kaji/kanyo-contemplating-falcons-dev:1.0.0-nvidia}
+  pull_policy: missing
+  env_file: .env
+  shm_size: '2gb'
+  command: ["/bin/sh", "-c", "umask 027 && exec python -m kanyo.detection.buffer_monitor"]
+  environment:
+    - PYTHONUNBUFFERED=1
+    - MALLOC_ARENA_MAX=2
+    - MALLOC_MMAP_THRESHOLD_=131072
+    - MALLOC_TRIM_THRESHOLD_=131072
+  deploy:
+    resources:
+      reservations:
+        devices:
+          - driver: nvidia
+            count: 1
+            capabilities: [gpu]
+  restart: unless-stopped
+  logging:
+    driver: "json-file"
+    options:
+      max-size: "10m"
+      max-file: "3"
+
+# =============================================================================
+# Services — one detector per stream + admin dashboard
+# =============================================================================
+services:
+  harvard-gpu:
+    <<: *kanyo-gpu-service
+    container_name: kanyo-harvard-gpu
+    volumes:
+      - ${KANYO_CODE_ROOT}/cookies.txt:/app/cookies.txt:rw
+      - ${KANYO_CAM1_ROOT}/config.yaml:/app/config.yaml:ro
+      - ${KANYO_CAM1_ROOT}/clips:/app/clips
+      - ${KANYO_CAM1_ROOT}/logs:/app/logs
+
+  nsw-gpu:
+    <<: *kanyo-gpu-service
+    container_name: kanyo-nsw-gpu
+    volumes:
+      - ${KANYO_CODE_ROOT}/cookies.txt:/app/cookies.txt:rw
+      - ${KANYO_CAM2_ROOT}/config.yaml:/app/config.yaml:ro
+      - ${KANYO_CAM2_ROOT}/clips:/app/clips
+      - ${KANYO_CAM2_ROOT}/logs:/app/logs
+
+  fortwayne-gpu:
+    <<: *kanyo-gpu-service
+    container_name: kanyo-fortwayne-gpu
+    volumes:
+      - ${KANYO_CODE_ROOT}/cookies.txt:/app/cookies.txt:rw
+      - ${KANYO_CAM4_ROOT}/config.yaml:/app/config.yaml:ro
+      - ${KANYO_CAM4_ROOT}/clips:/app/clips
+      - ${KANYO_CAM4_ROOT}/logs:/app/logs
+
+  umass-gpu:
+    <<: *kanyo-gpu-service
+    container_name: kanyo-umass-gpu
+    volumes:
+      - ${KANYO_CODE_ROOT}/cookies.txt:/app/cookies.txt:rw
+      - ${KANYO_CAM5_ROOT}/config.yaml:/app/config.yaml:ro
+      - ${KANYO_CAM5_ROOT}/clips:/app/clips
+      - ${KANYO_CAM5_ROOT}/logs:/app/logs
+
+  # bigbear is defined but not normally running (matches the host). Start it
+  # explicitly with:  docker compose --profile bigbear up -d bigbear-gpu
+  bigbear-gpu:
+    <<: *kanyo-gpu-service
+    container_name: kanyo-bigbear-gpu
+    profiles: ["bigbear"]
+    volumes:
+      - ${KANYO_CODE_ROOT}/cookies.txt:/app/cookies.txt:rw
+      - ${KANYO_CAM6_ROOT}/config.yaml:/app/config.yaml:ro
+      - ${KANYO_CAM6_ROOT}/clips:/app/clips
+      - ${KANYO_CAM6_ROOT}/logs:/app/logs
+
+  # ---------------------------------------------------------------------------
+  # Admin dashboard — built ON THE HOST from the kanyo-code checkout.
+  # This is the one service that still depends on ${KANYO_CODE_ROOT} source:
+  # rebuild with  docker compose up -d --build dashboard  (or ops/update-admin.sh).
+  # ---------------------------------------------------------------------------
+  dashboard:
+    build: ${KANYO_CODE_ROOT}/admin/web
+    image: kanyo-admin-dashboard:latest
+    container_name: kanyo-admin-web
+    env_file: .env
+    group_add:
+      - "988"                            # docker group — needed for socket access
+    ports:
+      - "5000:5000"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ${KANYO_CAM1_ROOT}:/data/harvard
+      - ${KANYO_CAM2_ROOT}:/data/nsw
+      - ${KANYO_CAM4_ROOT}:/data/fortwayne
+      - ${KANYO_CAM5_ROOT}:/data/umass
+      - ${KANYO_CAM6_ROOT}:/data/bigbear
+    restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+# =============================================================================
+# Dev mode — legacy src-mount override (DEVELOPMENT ONLY)
+# =============================================================================
+# Production runs the code baked into the pinned image. For rapid iteration on
+# a dev host you can override the baked code with a live source mount, so a
+# git pull + container restart picks up changes without an image rebuild.
+#
+# To enable for a service, add the src mount as the FIRST volume:
+#
+#   harvard-gpu:
+#     <<: *kanyo-gpu-service
+#     container_name: kanyo-harvard-gpu
+#     volumes:
+#       - ${KANYO_CODE_ROOT}/src:/app/src:ro          # DEV ONLY — overrides image code
+#       - ${KANYO_CODE_ROOT}/cookies.txt:/app/cookies.txt:rw
+#       - ${KANYO_CAM1_ROOT}/config.yaml:/app/config.yaml:ro
+#       - ${KANYO_CAM1_ROOT}/clips:/app/clips
+#       - ${KANYO_CAM1_ROOT}/logs:/app/logs
+#
+# Update cycle:  cd ${KANYO_CODE_ROOT} && git pull && docker compose restart <svc>
+#
+# Do not run production this way: a src mount makes the running code invisible
+# to image tags, so "what version is deployed" has no reliable answer.
+# =============================================================================

--- a/docs/deployment-kanyo.md
+++ b/docs/deployment-kanyo.md
@@ -1,0 +1,295 @@
+# Deployment Plan — kanyo.lan, v1.0.0
+
+The full deployment plan for moving the production host (`kanyo`, reachable as
+kanyo.lan on the LAN or via Tailscale) to image-based detector deployment at
+v1.0.0, plus the accompanying viewer, dashboard, and per-site config updates.
+
+**Scope of this deploy:**
+
+- Detectors move from src-mounted `:nvidia` (stale image, 2026-04-21) to the
+  pinned `1.0.0-nvidia` image. The src mount is removed.
+- Deployed image is the **nvidia** flavor (`1.0.0-nvidia`). There is no bare
+  `:1.0.0` tag — semver tags are flavor-suffixed.
+- **yolov8n stays.** The yolov8s model upgrade is deferred to a later deploy;
+  weights are baked into the image, so that will ship as a new image version.
+- Admin dashboard remains host-built from the `kanyo-code` checkout.
+- Viewer (separate repo/compose project) updated via its own git pull + build.
+- Per-site config tuning for fortwayne and harvard; umass and nsw stay on
+  template defaults.
+
+All commands run from the Mac unless prefixed `# on host`. Host compose
+commands need `sudo` (use `ssh -t` for interactive sudo).
+
+---
+
+## Phase 0 — Preflight
+
+1. **Release exists.** After the deployment PR merges to main, tag and push:
+   ```bash
+   git tag v1.0.0 && git push origin v1.0.0
+   ```
+   Wait for the "Build and Publish Docker Image" workflow to finish, then
+   confirm the tag is on GHCR:
+   ```bash
+   gh api "/orgs/sageframe-no-kaji/packages/container/kanyo-contemplating-falcons-dev/versions" \
+     --jq '.[].metadata.container.tags[]' | grep '1.0.0-nvidia'
+   ```
+2. **Host reachable, fleet healthy before touching anything:**
+   ```bash
+   ssh kanyo 'cd /opt/services/kanyo-admin && sudo docker compose ps'
+   ```
+   Expect harvard, nsw, fortwayne, umass detectors + `kanyo-admin-web` all Up.
+3. **Disk headroom** for a ~7 GB image pull:
+   ```bash
+   ssh kanyo 'df -h /var/lib/docker && df -h /opt/services'
+   ```
+4. **Snapshot the current state** (rollback anchors):
+   ```bash
+   ssh kanyo 'cd /opt/services/kanyo-admin && \
+     sudo cp docker-compose.yml docker-compose.yml.pre-v1.0.0 && \
+     sudo cp .env .env.pre-v1.0.0 && \
+     cd /opt/services/kanyo-code && git rev-parse HEAD'
+   ```
+   Record the printed `kanyo-code` commit — it is the admin/dev rollback point.
+5. **Note current per-site configs:**
+   ```bash
+   ssh kanyo 'for s in harvard nsw fortwayne umass; do \
+     sudo cp /opt/services/kanyo-$s/config.yaml /opt/services/kanyo-$s/config.yaml.pre-v1.0.0; done'
+   ```
+
+---
+
+## Phase 1 — Viewer (separate repo, own compose project)
+
+The viewer is its own checkout and compose project at
+`/opt/services/kanyo-viewer` and does not touch the detector fleet.
+
+```bash
+ssh kanyo 'cd /opt/services/kanyo-viewer && git pull'
+ssh -t kanyo 'cd /opt/services/kanyo-viewer && sudo docker compose up -d --build'
+```
+
+Verify:
+
+```bash
+ssh kanyo 'curl -s -o /dev/null -w "%{http_code}\n" http://localhost:3000/'   # expect 200
+```
+
+Spot-check https://kanyo.sageframe.net (via the Cloudflare tunnel) loads and
+shows current clips.
+
+---
+
+## Phase 2 — kanyo-code pull + dashboard rebuild
+
+The host checkout remains as the admin build source, `cookies.txt` home, and
+ops-script carrier. Pull it to the release commit and rebuild the dashboard:
+
+```bash
+./ops/update-admin.sh          # git pull kanyo-code + rebuild dashboard container
+```
+
+Verify:
+
+```bash
+ssh kanyo 'curl -s -o /dev/null -w "%{http_code}\n" http://localhost:5000/'   # expect 200/401 (basic auth)
+ssh kanyo 'sudo docker logs kanyo-admin-web --tail 30'
+```
+
+Dashboard shows all four streams with correct status.
+
+---
+
+## Phase 3 — Per-site config edits
+
+Edit on the host (`sudo`, files owned 1000:1000). Keys are documented in
+`configs/config.template.yaml`. Only set the keys listed; leave the rest as-is.
+
+**fortwayne** (`/opt/services/kanyo-fortwayne/config.yaml`):
+
+```yaml
+min_significant_seconds: 60
+damping_arrivals_threshold: 6
+```
+
+**harvard** (`/opt/services/kanyo-harvard/config.yaml`):
+
+```yaml
+presence_sustain_confidence: 0.10
+merge_window_seconds: 120
+min_significant_seconds: 15
+damping_arrivals_threshold: 10
+```
+
+**umass, nsw** — no edits; they run template defaults
+(`presence_sustain_confidence: 0.15`, `merge_window_seconds: 300`,
+`min_significant_seconds: 30`, `damping_arrivals_threshold: 8`).
+
+Config changes take effect when containers are recreated in Phase 5 — no
+separate restart needed.
+
+---
+
+## Phase 4 — Switch to the new compose template + pull image
+
+1. **Install the new template** (from the repo's `docker/docker-compose.yml`;
+   the old file was backed up in Phase 0):
+   ```bash
+   scp docker/docker-compose.yml kanyo:/tmp/docker-compose.yml
+   ssh -t kanyo 'sudo mv /tmp/docker-compose.yml /opt/services/kanyo-admin/docker-compose.yml && \
+     sudo chown 1000:1000 /opt/services/kanyo-admin/docker-compose.yml'
+   ```
+2. **Migrate `.env`** — keep the existing values (`TELEGRAM_BOT_TOKEN`,
+   `KANYO_CODE_ROOT`, `KANYO_CAM{1,2,4,5,6}_ROOT`) and add the image pin:
+   ```bash
+   ssh kanyo 'cd /opt/services/kanyo-admin && \
+     grep -q "^KANYO_IMAGE=" .env || \
+     echo "KANYO_IMAGE=ghcr.io/sageframe-no-kaji/kanyo-contemplating-falcons-dev:1.0.0-nvidia" | sudo tee -a .env'
+   ```
+3. **Sanity-check the merged compose config** (fails loudly on missing vars):
+   ```bash
+   ssh kanyo 'cd /opt/services/kanyo-admin && sudo docker compose config --quiet && echo OK'
+   ```
+4. **Pull the release image** (big pull; detectors keep running on the old
+   image until recreate):
+   ```bash
+   ssh -t kanyo 'cd /opt/services/kanyo-admin && sudo docker compose pull harvard-gpu'
+   ```
+
+---
+
+## Phase 5 — Canary harvard, then fleet
+
+Phases 4+5 are exactly what `./ops/update-code.sh 1.0.0-nvidia` automates
+(minus the template copy). Run the script, or do it by hand:
+
+```bash
+ssh -t kanyo 'cd /opt/services/kanyo-admin && sudo docker compose up -d --force-recreate harvard-gpu'
+ssh kanyo 'sudo docker logs kanyo-harvard-gpu --tail 200 -f'
+```
+
+### Canary log-verification checklist (harvard)
+
+Watch the log until every box ticks. Give it at least one 5-minute summary
+cycle (~6–7 minutes) before rolling the fleet.
+
+- [ ] **Config loads clean** — config banner shows the Phase 3 values
+      (`presence_sustain_confidence: 0.10`, `merge_window_seconds: 120`,
+      `min_significant_seconds: 15`, `damping_arrivals_threshold: 10`);
+      no unknown-key or validation warnings.
+- [ ] **YOLO loads** — yolov8n model load line, CUDA device detected, no
+      "CUDA not available / falling back to CPU" warning.
+- [ ] **Stream connects** — yt-dlp resolves the Harvard stream and frames
+      start flowing (no repeated 403s — that would be the IP-ban pattern).
+- [ ] **Presence lines** — periodic presence/state-machine lines appear; no
+      tracebacks.
+- [ ] **5-min confidence summary** — the periodic confidence summary line
+      arrives on schedule with plausible values.
+- [ ] **Admin healthy** — dashboard still shows harvard Up and can read its
+      logs/clips.
+- [ ] **No src mount** — confirm the container is running baked code:
+      ```bash
+      ssh kanyo 'sudo docker inspect kanyo-harvard-gpu --format "{{range .Mounts}}{{.Destination}} {{end}}"'
+      ```
+      Must list `/app/cookies.txt /app/config.yaml /app/clips /app/logs` —
+      **no `/app/src`**.
+
+### Fleet
+
+```bash
+ssh -t kanyo 'cd /opt/services/kanyo-admin && sudo docker compose pull && \
+  sudo docker compose up -d --force-recreate nsw-gpu fortwayne-gpu umass-gpu'
+```
+
+(bigbear stays defined-but-stopped; it is behind the `bigbear` compose profile.)
+
+---
+
+## Phase 6 — Post-deploy verification
+
+```bash
+ssh kanyo 'cd /opt/services/kanyo-admin && sudo docker compose ps'
+```
+
+- [ ] All four detectors + dashboard Up; no restart loops (`RESTARTING`/crash
+      counts) after 10 minutes.
+- [ ] Each detector passes the abbreviated canary checklist (config, YOLO,
+      stream, presence lines) — `sudo docker logs kanyo-<site>-gpu --tail 100`.
+- [ ] Running image is the pinned tag on every detector:
+  ```bash
+  ssh kanyo 'for s in harvard nsw fortwayne umass; do \
+    sudo docker inspect kanyo-$s-gpu --format "$s: {{.Config.Image}}"; done'
+  ```
+- [ ] Clips still being written: check `clips/$(date +%Y-%m-%d)/` for new files
+      after the next arrival (or within a few hours on active cams).
+- [ ] Viewer (kanyo.sageframe.net) and admin (`:5000`) both serving.
+- [ ] GPU in use: `ssh kanyo nvidia-smi` shows the python processes.
+
+Leave the Phase 0 backups in place for at least a week of clean operation,
+then remove the `*.pre-v1.0.0` files.
+
+---
+
+## Rollback
+
+Each layer rolls back independently; use the smallest one that fixes the
+problem.
+
+**Detectors — image repoint** (seconds; old image is still on disk):
+
+```bash
+ssh kanyo 'cd /opt/services/kanyo-admin && \
+  sudo sed -i "s|^KANYO_IMAGE=.*|KANYO_IMAGE=ghcr.io/sageframe-no-kaji/kanyo-contemplating-falcons-dev:nvidia|" .env'
+ssh -t kanyo 'cd /opt/services/kanyo-admin && sudo docker compose up -d --force-recreate harvard-gpu nsw-gpu fortwayne-gpu umass-gpu'
+```
+
+**Detectors — full template rollback** (restores the src-mount world exactly
+as it was):
+
+```bash
+ssh -t kanyo 'cd /opt/services/kanyo-admin && \
+  sudo cp docker-compose.yml.pre-v1.0.0 docker-compose.yml && \
+  sudo cp .env.pre-v1.0.0 .env && \
+  sudo docker compose up -d --force-recreate'
+```
+
+**Admin dashboard** — pin `kanyo-code` back and rebuild:
+
+```bash
+ssh kanyo 'cd /opt/services/kanyo-code && git checkout <phase-0-commit>'
+ssh -t kanyo 'cd /opt/services/kanyo-admin && sudo docker compose up -d --build dashboard'
+```
+
+**Viewer** — same pattern in its own project:
+
+```bash
+ssh kanyo 'cd /opt/services/kanyo-viewer && git checkout <previous-commit>'
+ssh -t kanyo 'cd /opt/services/kanyo-viewer && sudo docker compose up -d --build'
+```
+
+**Per-site configs** — restore the Phase 0 copies:
+
+```bash
+ssh kanyo 'sudo cp /opt/services/kanyo-<site>/config.yaml.pre-v1.0.0 /opt/services/kanyo-<site>/config.yaml'
+ssh -t kanyo 'cd /opt/services/kanyo-admin && sudo docker compose restart <site>-gpu'
+```
+
+**Behavioral rollback (no image change)** — if the new presence/significance
+behavior misfires on a site, disable it per-site in that site's `config.yaml`
+and restart just that container:
+
+```yaml
+presence_enabled: false             # restores legacy presence behavior
+significance_filter_enabled: false  # restores unfiltered arrival/departure events
+```
+
+---
+
+## Deferred / out of scope for this deploy
+
+- **yolov8s** — model upgrade ships as a later image version (weights are
+  baked at build).
+- **bigbear** — stays defined-but-stopped behind the `bigbear` profile.
+- **Admin dashboard image-based build** — dashboard stays host-built; moving
+  it to a published image is a later decision.
+- **CPU/VAAPI flavors** — production is nvidia-only.

--- a/docs/docker-architecture.md
+++ b/docs/docker-architecture.md
@@ -21,8 +21,8 @@ Describes how the Docker services are organized across the two repos and what ea
 │   ├── docker-compose.yml
 │   └── ban-watch.sh           ← IP ban detection script (runs in tmux, not Docker)
 │
-├── kanyo-code/                ← source checkout — mounted live into stream containers
-│   ├── src/
+├── kanyo-code/                ← source checkout — admin build source + ops scripts
+│   ├── src/                   ← NOT mounted into containers (image-based deploy)
 │   └── cookies.txt            ← shared YouTube auth cookies for all streams
 │
 ├── kanyo-harvard/             ← stream data (ZFS dataset)
@@ -55,31 +55,27 @@ Describes how the Docker services are organized across the two repos and what ea
 
 ## Services
 
-### Detection streams (5 active)
+### Detection streams (4 running, bigbear defined-but-stopped)
 
-**Containers:** `kanyo-harvard-gpu`, `kanyo-nsw-gpu`, `kanyo-fortwayne-gpu`, `kanyo-umass-gpu`, `kanyo-bigbear-gpu`  
-**Image:** `ghcr.io/sageframe-no-kaji/kanyo-contemplating-falcons-dev:nvidia`  
-**Managed by:** `kanyo-admin/docker-compose.yml`
+**Containers:** `kanyo-harvard-gpu`, `kanyo-nsw-gpu`, `kanyo-fortwayne-gpu`, `kanyo-umass-gpu` (+ `kanyo-bigbear-gpu`, defined behind the `bigbear` compose profile, not normally running)  
+**Image:** `ghcr.io/sageframe-no-kaji/kanyo-contemplating-falcons-dev:<version>-nvidia` (pinned semver, selected by `KANYO_IMAGE` in `.env`)  
+**Managed by:** `kanyo-admin/docker-compose.yml` (host copy of [docker/docker-compose.yml](../docker/docker-compose.yml))
 
-All five stream containers are defined in one compose file using a YAML anchor (`x-kanyo-gpu-service`) so they share the same GPU config, resource limits, and logging settings. Only the container name and data volume paths differ per stream.
+All stream containers are defined in one compose file using a YAML anchor (`x-kanyo-gpu-service`) so they share the same GPU config, resource limits, and logging settings. Only the container name and data volume paths differ per stream.
 
-**Source code is volume-mounted** from `kanyo-code/src` into every container at `/app/src`, overriding the code baked into the image. This means a `git pull` in `kanyo-code/` + compose restart picks up changes in ~10 seconds with no image rebuild.
+**Deployment is image-based** — the detectors run the code baked into the pinned release image; no source is mounted. Upgrades and rollbacks are image-tag repoints (see [docker/DOCKER-DEPLOYMENT.md](../docker/DOCKER-DEPLOYMENT.md)). A live `src/` mount from `kanyo-code` remains available as a dev-only override, documented in the compose template.
 
 **`cookies.txt` is shared** — a single file at `kanyo-code/cookies.txt` is mounted into all stream containers. Used for YouTube streams that require authenticated access.
 
 ```yaml
 x-kanyo-gpu-service: &kanyo-gpu-service
-  image: ghcr.io/sageframe-no-kaji/kanyo-contemplating-falcons-dev:nvidia
-  volumes:
-    - ${KANYO_CODE_ROOT}/src:/app/src:ro        # live source mount
-    - ${KANYO_CODE_ROOT}/cookies.txt:/app/cookies.txt:rw
+  image: ${KANYO_IMAGE:-ghcr.io/sageframe-no-kaji/kanyo-contemplating-falcons-dev:1.0.0-nvidia}
 
 services:
   harvard-gpu:
     <<: *kanyo-gpu-service
     container_name: kanyo-harvard-gpu
     volumes:
-      - ${KANYO_CODE_ROOT}/src:/app/src:ro
       - ${KANYO_CODE_ROOT}/cookies.txt:/app/cookies.txt:rw
       - ${KANYO_CAM1_ROOT}/config.yaml:/app/config.yaml:ro
       - ${KANYO_CAM1_ROOT}/clips:/app/clips
@@ -193,7 +189,7 @@ YouTube live stream
         ▼
 [kanyo-{stream}-gpu]  ←── config.yaml    (stream settings)
         │              ←── cookies.txt   (shared from kanyo-code/)
-        │              ←── src/          (live volume mount from kanyo-code/)
+        │              (code baked into pinned image — no src mount)
         │
         ▼
 /opt/services/kanyo-{stream}/

--- a/ops/INDEX.md
+++ b/ops/INDEX.md
@@ -1,50 +1,65 @@
-# Scripts Index
+# Ops Index
 
-Utility scripts for building, deploying, and managing Kanyo.
-
-## Docker Image Building
-
-| Script | Purpose |
-|--------|---------|
-| `build-all.sh` | Build all Docker image variants (cpu, vaapi, nvidia) |
-| `build-cpu.sh` | Build CPU-only image |
-| `build-vaapi.sh` | Build Intel iGPU (VAAPI) image |
-| `build-nvidia.sh` | Build NVIDIA GPU image |
+Operational scripts for deploying and managing Kanyo. Deployment scripts run
+from the Mac and operate on the production host (`kanyo`, reachable as
+kanyo.lan / via Tailscale) over SSH.
 
 ## Deployment
 
 | Script | Purpose |
 |--------|---------|
-| `deploy-nvidia.sh` | Full deployment with NVIDIA image to production |
-| `deploy-production.sh` | Deploy to production server |
-| `update-code.sh` | Quick code update via git pull + container restart |
-| `update-admin.sh` | Update admin GUI on production |
-| `update-production.sh` | Update production deployment |
+| `update-code.sh` | Deploy a pinned detector image to production: repoint `KANYO_IMAGE`, pull, canary harvard, then fleet. Usage: `./ops/update-code.sh 1.0.0-nvidia` |
+| `update-admin.sh` | Update the admin dashboard: git pull `kanyo-code` on the host + rebuild the host-built dashboard container |
 
-## Utilities
+## Host Utilities
 
 | Script | Purpose |
 |--------|---------|
+| `ban-watch.sh` | Runs on the host in tmux; polls YouTube to detect when an IP ban lifts, notifies via ntfy |
 | `event-search.sh` | Search through event JSON files (see `event-search-README.md`) |
+
+## Local Image Building (`build/`)
+
+CI builds and publishes the `cpu` and `nvidia` images on push/tag; these are
+for local builds only (`vaapi` is not CI-built).
+
+| Script | Purpose |
+|--------|---------|
+| `build/build-cpu.sh` | Build CPU-only image locally |
+| `build/build-nvidia.sh` | Build NVIDIA GPU image locally |
+| `build/build-vaapi.sh` | Build Intel iGPU (VAAPI) image locally |
+
+## Archive (`archive/`)
+
+Superseded scripts, kept for reference. Do not use in production.
+
+| Script | Superseded by |
+|--------|---------------|
+| `archive/update-code-gitpull.sh` | `update-code.sh` (image-based deploy replaced the git-pull + src-mount route at v1.0.0; git-pull remains a documented dev-only option) |
+| `archive/build-all.sh` | CI (`.github/workflows/build.yml`) + `build/` scripts |
+| `archive/deploy-nvidia.sh` | `docs/deployment-kanyo.md` + `update-code.sh` |
+| `archive/deploy-production.sh` | `docs/deployment-kanyo.md` + `update-code.sh` |
+| `archive/update-production.sh` | `update-code.sh` |
 
 ## Usage Examples
 
-### Build and push NVIDIA image
+### Deploy a release to production (canary, then fleet)
 ```bash
-./scripts/build-nvidia.sh
+./ops/update-code.sh 1.0.0-nvidia
 ```
 
-### Quick code update (no image rebuild)
+### Update the admin dashboard
 ```bash
-./scripts/update-code.sh shingan.lan
+./ops/update-admin.sh
 ```
 
 ### Search for events
 ```bash
-./scripts/event-search.sh "ARRIVED" /opt/services/kanyo-harvard/clips
+./ops/event-search.sh "ARRIVED" /opt/services/kanyo-harvard/clips
 ```
 
 ## See Also
 
-- [QUICKSTART.md](../QUICKSTART.md) — Getting started
-- [docker/DOCKER-DEPLOYMENT.md](../docker/DOCKER-DEPLOYMENT.md) — Full deployment guide
+- [docs/deployment-kanyo.md](../docs/deployment-kanyo.md) — production deploy plan
+- [docker/DOCKER-DEPLOYMENT.md](../docker/DOCKER-DEPLOYMENT.md) — deployment guide
+- [Quickstart.md](../Quickstart.md) — getting started

--- a/ops/archive/update-code-gitpull.sh
+++ b/ops/archive/update-code-gitpull.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Update detection code: pull latest, rebuild admin, restart all stream containers
+
+set -e
+
+REMOTE_HOST="${1:-kanyo}"
+CODE_DIR="/opt/services/kanyo-code"
+ADMIN_DIR="/opt/services/kanyo-admin"
+
+echo "Updating code on ${REMOTE_HOST}..."
+
+echo "📥 Pulling latest code..."
+ssh "${REMOTE_HOST}" "cd ${CODE_DIR} && git pull"
+
+echo "🔨 Rebuilding admin container..."
+ssh -t "${REMOTE_HOST}" "cd ${ADMIN_DIR} && sudo docker compose up -d --build dashboard"
+
+echo "🔄 Restarting stream containers..."
+ssh -t "${REMOTE_HOST}" "cd ${ADMIN_DIR} && sudo docker compose restart harvard-gpu fortwayne-gpu umass-gpu nsw-gpu"
+
+echo ""
+echo "✓ Code updated and containers restarted!"
+echo "  Logs: ssh ${REMOTE_HOST} 'cd ${ADMIN_DIR} && sudo docker compose logs -f'"

--- a/ops/update-code.sh
+++ b/ops/update-code.sh
@@ -1,23 +1,75 @@
 #!/bin/bash
-# Update detection code: pull latest, rebuild admin, restart all stream containers
+# Deploy a pinned detector image to production (image-based deployment).
+#
+# Repoints KANYO_IMAGE in the host's /opt/services/kanyo-admin/.env to the
+# given tag, pulls it, then recreates the detector fleet with a canary first:
+# harvard-gpu is recreated alone, you verify its logs, and only after
+# confirmation does the rest of the fleet roll.
+#
+# Usage:
+#   ./ops/update-code.sh <image-tag> [remote-host]
+#   ./ops/update-code.sh 1.0.0-nvidia
+#   ./ops/update-code.sh 1.1.0-nvidia kanyo
+#
+# Rollback is the same command with the previous tag.
+#
+# The legacy git-pull + restart route (src-mounted code) is archived at
+# ops/archive/update-code-gitpull.sh and is dev-only now.
 
 set -e
 
-REMOTE_HOST="${1:-kanyo}"
-CODE_DIR="/opt/services/kanyo-code"
+IMAGE_TAG="${1:-}"
+REMOTE_HOST="${2:-kanyo}"
+IMAGE_REPO="ghcr.io/sageframe-no-kaji/kanyo-contemplating-falcons-dev"
 ADMIN_DIR="/opt/services/kanyo-admin"
+CANARY="harvard-gpu"
+FLEET="nsw-gpu fortwayne-gpu umass-gpu"
 
-echo "Updating code on ${REMOTE_HOST}..."
+if [ -z "${IMAGE_TAG}" ]; then
+    echo "Usage: $0 <image-tag> [remote-host]"
+    echo "Example: $0 1.0.0-nvidia"
+    echo "Example: $0 1.1.0-nvidia kanyo"
+    exit 1
+fi
 
-echo "📥 Pulling latest code..."
-ssh "${REMOTE_HOST}" "cd ${CODE_DIR} && git pull"
+IMAGE="${IMAGE_REPO}:${IMAGE_TAG}"
 
-echo "🔨 Rebuilding admin container..."
-ssh -t "${REMOTE_HOST}" "cd ${ADMIN_DIR} && sudo docker compose up -d --build dashboard"
+echo "Deploying ${IMAGE} to ${REMOTE_HOST}..."
+echo ""
 
-echo "🔄 Restarting stream containers..."
-ssh -t "${REMOTE_HOST}" "cd ${ADMIN_DIR} && sudo docker compose restart harvard-gpu fortwayne-gpu umass-gpu nsw-gpu"
+echo "📌 Pinning KANYO_IMAGE in ${ADMIN_DIR}/.env..."
+ssh "${REMOTE_HOST}" "cd ${ADMIN_DIR} && \
+    if grep -q '^KANYO_IMAGE=' .env; then \
+        sed -i 's|^KANYO_IMAGE=.*|KANYO_IMAGE=${IMAGE}|' .env; \
+    else \
+        echo 'KANYO_IMAGE=${IMAGE}' >> .env; \
+    fi && grep '^KANYO_IMAGE=' .env"
+
+echo "📥 Pulling image..."
+ssh -t "${REMOTE_HOST}" "cd ${ADMIN_DIR} && sudo docker compose pull ${CANARY}"
+
+echo "🐤 Canary: recreating ${CANARY}..."
+ssh -t "${REMOTE_HOST}" "cd ${ADMIN_DIR} && sudo docker compose up -d --force-recreate ${CANARY}"
 
 echo ""
-echo "✓ Code updated and containers restarted!"
-echo "  Logs: ssh ${REMOTE_HOST} 'cd ${ADMIN_DIR} && sudo docker compose logs -f'"
+echo "Canary is up. Verify before rolling the fleet:"
+echo "  ssh ${REMOTE_HOST} 'sudo docker logs kanyo-harvard-gpu --tail 100 -f'"
+echo "Checklist: config loads clean, YOLO loads, stream connects, presence"
+echo "lines appearing, no tracebacks (see docs/deployment-kanyo.md)."
+echo ""
+read -p "Canary healthy — recreate the rest of the fleet (${FLEET})? (y/N) " -n 1 -r
+echo
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo "Stopping after canary. Fleet still on previous image."
+    echo "Roll forward later:  ssh ${REMOTE_HOST} 'cd ${ADMIN_DIR} && sudo docker compose up -d --force-recreate ${FLEET}'"
+    echo "Roll canary back:    $0 <previous-tag> ${REMOTE_HOST}"
+    exit 0
+fi
+
+echo "🔄 Recreating fleet..."
+ssh -t "${REMOTE_HOST}" "cd ${ADMIN_DIR} && sudo docker compose up -d --force-recreate ${FLEET}"
+
+echo ""
+echo "✓ Fleet deployed on ${IMAGE}!"
+echo "  Status: ssh ${REMOTE_HOST} 'cd ${ADMIN_DIR} && sudo docker compose ps'"
+echo "  Logs:   ssh ${REMOTE_HOST} 'cd ${ADMIN_DIR} && sudo docker compose logs -f'"


### PR DESCRIPTION
## What

Moves the detector fleet from src-mounted code over a stale `:nvidia` image to **image-based deployment on pinned semver tags**, and adds the full v1.0.0 deployment plan for the production host (kanyo.lan).

## Changes

- **docker/docker-compose.yml** — now the tracked canonical production template (`.gitignore` negation added; the file was previously untracked/ignored). Mirrors the real host shape: x-anchor base service, harvard/nsw/fortwayne/umass detectors, bigbear defined behind a `bigbear` compose profile (defined-but-stopped, as on the host), host-built admin dashboard, `KANYO_IMAGE` env pin, shared `cookies.txt` mount, per-site config/clips/logs via env roots, **no src mount**. Commented dev-only src-mount override at the bottom.
- **docker/DOCKER-DEPLOYMENT.md** — rewritten: image-based route is the deployment path (pull pinned tag, `--force-recreate`); upgrade/rollback = tag repoint; dev git-pull route clearly separated and marked dev-only; config keys defer to `configs/config.template.yaml`; stale single-stream/curl instructions removed.
- **.github/workflows/build.yml** — semver image tags are now flavor-suffixed (`1.0.0-nvidia` / `1.0.0-cpu`, plus `major.minor` variants). Previously only `build-cpu` had semver patterns, so `:1.0.0` would have been the **CPU** image and no nvidia semver tag would exist at all — the GPU host would have pulled CPU inference. Branch (`cpu`/`nvidia`) and sha tags unchanged.
- **ops/update-code.sh** — now the image-based deploy script: `./ops/update-code.sh <tag> [host]` repoints `KANYO_IMAGE` in the host `.env`, pulls, canaries harvard, waits for confirmation, then rolls the fleet. Old git-pull version archived as `ops/archive/update-code-gitpull.sh`; `ops/INDEX.md` rewritten to match the actual `ops/` layout (it still referenced the pre-reorg `scripts/` paths and listed archived scripts as active). `ops/update-admin.sh` verified correct and unchanged (dashboard stays host-built).
- **docs/deployment-kanyo.md** — full phased deploy plan: preflight (tag v1.0.0 after this merges, backups), viewer, kanyo-code pull + dashboard rebuild, per-site config tuning (fortwayne + harvard; umass/nsw on defaults), compose template switch + .env migration, canary harvard with a log-verification checklist, fleet, post-deploy verification, and layered rollbacks (image repoint / template restore / git checkout / `presence_enabled`+`significance_filter_enabled` behavioral rollback). yolov8s explicitly deferred; deployed flavor is nvidia.
- **docker/.env.example** — adds `KANYO_IMAGE` and the missing CAM4/5/6 roots.
- **docs/docker-architecture.md** — updated to the image-based reality (no src mount; 4 running + bigbear stopped).
- **README.md** — short Versioning section (v1.0.0 first stable release, semver, image tags track git tags).

## After merge

Tag the release: `git tag v1.0.0 && git push origin v1.0.0`, then follow `docs/deployment-kanyo.md`.

## Verification

- `bash -n` clean on all touched scripts
- `docker compose config` clean against a stub `.env` (with and without the `bigbear` profile; image resolves to `...:1.0.0-nvidia`)
- workflow YAML parses
- no changes under `src/`, `tests/`, or `pytest.ini`