### PR TITLE
027: fix ffmpeg log cleanup to delete the log file that actually exists

### DIFF
--- a/src/kanyo/detection/buffer_clip_manager.py
+++ b/src/kanyo/detection/buffer_clip_manager.py
@@ -403,7 +403,7 @@ class BufferClipManager:
         Returns:
             Tuple of (clip_path, recorder) or (None, None) if failed
         """
-        from kanyo.utils.visit_recorder import VisitRecorder
+        from kanyo.utils.visit_recorder import VisitRecorder, ffmpeg_log_path
 
         # Create clip path with .tmp extension while recording
         final_clip_path = get_output_path(
@@ -527,7 +527,7 @@ class BufferClipManager:
         logger.event(f"📹 Starting arrival clip recording: {clip_path}")
 
         try:
-            stderr_log = clip_path.with_suffix(".ffmpeg.log")
+            stderr_log = ffmpeg_log_path(clip_path)
             temp_recorder._stderr_file = open(stderr_log, "w")
 
             temp_recorder._process = subprocess.Popen(

--- a/src/kanyo/utils/arrival_clip_recorder.py
+++ b/src/kanyo/utils/arrival_clip_recorder.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from kanyo.utils.logger import get_logger
+from kanyo.utils.visit_recorder import ffmpeg_log_path
 
 if TYPE_CHECKING:
     from kanyo.detection.buffer_clip_manager import BufferClipManager
@@ -66,7 +67,9 @@ class ArrivalClipRecorder:
         """
         if self._recorder is not None:
             # Rapid swap or slow-stream starvation left previous clip open; close it first.
-            logger.warning("Arrival clip still active on new arrival — stopping before starting new one")
+            logger.warning(
+                "Arrival clip still active on new arrival — stopping before starting new one"
+            )
             self.stop_recording(datetime.now(timezone.utc))
 
         clip_duration = self.clip_manager.clip_arrival_before + self.clip_manager.clip_arrival_after
@@ -138,9 +141,11 @@ class ArrivalClipRecorder:
         if final_path:
             clip_path = final_path
 
-        # Delete FFmpeg log file after successful recording
+        # Delete FFmpeg log file after successful recording. The log was
+        # created against the .mp4.tmp path; ffmpeg_log_path() resolves the
+        # same name whether clip_path is the renamed final .mp4 or the .tmp.
         if clip_path:
-            ffmpeg_log = clip_path.with_suffix(".ffmpeg.log")
+            ffmpeg_log = ffmpeg_log_path(clip_path)
             if ffmpeg_log.exists():
                 try:
                     ffmpeg_log.unlink()

--- a/src/kanyo/utils/visit_recorder.py
+++ b/src/kanyo/utils/visit_recorder.py
@@ -26,6 +26,30 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
+def ffmpeg_log_path(recording_path: Path) -> Path:
+    """
+    Return the ffmpeg stderr log path for a recording.
+
+    The log always lives at ``<name>.mp4.ffmpeg.log``, whether the
+    recording is still at its ``.mp4.tmp`` working path or has been
+    renamed to its final ``.mp4``. Every creation and cleanup site must
+    compute the log path through this function — recordings are renamed
+    from ``.tmp`` to ``.mp4`` on confirmation, and computing the name
+    ad hoc with ``with_suffix`` (which replaces only the last suffix)
+    made the two sides of the create/delete pair disagree.
+
+    Args:
+        recording_path: Recording path, either ``.mp4`` or ``.mp4.tmp``
+
+    Returns:
+        Path of the stderr log beside the final recording
+    """
+    name = recording_path.name
+    if name.endswith(".tmp"):
+        name = name[: -len(".tmp")]
+    return recording_path.with_name(name + ".ffmpeg.log")
+
+
 class VisitRecorder:
     """
     Records entire falcon visits to video files.
@@ -272,7 +296,7 @@ class VisitRecorder:
             # Pipe buffers are finite (~64KB); if ffmpeg writes more than that
             # and we don't read it, ffmpeg blocks, which backs up stdin, which
             # blocks our write_frame() calls forever.
-            stderr_log = self._visit_path.with_suffix(".ffmpeg.log")
+            stderr_log = ffmpeg_log_path(self._visit_path)
             self._stderr_file = open(stderr_log, "w")
 
             self._process = subprocess.Popen(
@@ -490,7 +514,7 @@ class VisitRecorder:
 
         # Delete FFmpeg log file after successful recording (if confirmed)
         if self._confirmed and result_path:
-            ffmpeg_log = result_path.with_suffix(".ffmpeg.log")
+            ffmpeg_log = ffmpeg_log_path(result_path)
             if ffmpeg_log.exists():
                 try:
                     ffmpeg_log.unlink()
@@ -579,7 +603,7 @@ class VisitRecorder:
         logger.info(f"Extracting clip: {start_offset:.1f}s + {duration:.1f}s → {output_path}")
 
         # Write ffmpeg stderr to log file
-        ffmpeg_log = output_path.with_suffix(".ffmpeg.log")
+        ffmpeg_log = ffmpeg_log_path(output_path)
         try:
             with open(ffmpeg_log, "w") as stderr_file:
                 result = subprocess.run(

--- a/tests/test_arrival_clip_recorder.py
+++ b/tests/test_arrival_clip_recorder.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from unittest.mock import Mock
 
 from kanyo.utils.arrival_clip_recorder import ArrivalClipRecorder
+from kanyo.utils.visit_recorder import ffmpeg_log_path
 
 
 def make_clip_manager() -> Mock:
@@ -125,7 +126,8 @@ class TestStopRecording:
         """The renamed final path wins, and its ffmpeg log is cleaned up."""
         final_path = tmp_path / "falcon_100000_000000_arrival.mp4"
         final_path.write_text("clip")
-        ffmpeg_log = final_path.with_suffix(".ffmpeg.log")
+        # The log is created against the .mp4.tmp path -> X.mp4.ffmpeg.log
+        ffmpeg_log = ffmpeg_log_path(final_path)
         ffmpeg_log.write_text("ffmpeg output")
 
         acr = ArrivalClipRecorder(make_clip_manager())
@@ -145,7 +147,7 @@ class TestStopRecording:
         final_path = tmp_path / "falcon_100000_000000_arrival.mp4"
         final_path.write_text("clip")
         # A directory at the log path makes unlink() raise
-        ffmpeg_log = final_path.with_suffix(".ffmpeg.log")
+        ffmpeg_log = ffmpeg_log_path(final_path)
         ffmpeg_log.mkdir()
 
         acr = ArrivalClipRecorder(make_clip_manager())
@@ -161,7 +163,7 @@ class TestStopRecording:
         """Without a rename, cleanup targets the .tmp clip path."""
         clip_path = tmp_path / "falcon_100000_000000_arrival.mp4.tmp"
         clip_path.write_text("clip")
-        ffmpeg_log = clip_path.with_suffix(".ffmpeg.log")
+        ffmpeg_log = ffmpeg_log_path(clip_path)
         ffmpeg_log.write_text("ffmpeg output")
 
         acr = ArrivalClipRecorder(make_clip_manager())

--- a/tests/test_buffer_clip_manager.py
+++ b/tests/test_buffer_clip_manager.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
 
 from kanyo.detection.buffer_clip_manager import BufferClipManager
-from kanyo.utils.visit_recorder import VisitRecorder
+from kanyo.utils.visit_recorder import VisitRecorder, ffmpeg_log_path
 
 
 def make_manager(tmp_path, **kwargs):
@@ -557,6 +557,28 @@ class TestCreateStandaloneArrivalClip:
         ]
         assert recorder._process is mock_popen.return_value
         self._close_stderr(recorder)
+
+    @patch("kanyo.detection.buffer_clip_manager.subprocess.Popen")
+    def test_confirmed_stop_deletes_stderr_log(self, mock_popen, tmp_path):
+        """Regression (027): the log created for a standalone arrival clip
+        (X.mp4.ffmpeg.log, from the .tmp path) is deleted on confirmed stop."""
+        mock_popen.return_value.poll.return_value = None  # recorder is "running"
+        mock_popen.return_value.wait.return_value = 0
+        clip_path, recorder, _ = self._create(tmp_path, mock_popen, "libx264")
+
+        log_file = ffmpeg_log_path(clip_path)
+        assert log_file.exists()  # really opened by create_standalone_arrival_clip
+        assert log_file.name.endswith(".mp4.ffmpeg.log")
+
+        clip_path.write_bytes(b"fake mp4 data")
+        recorder.rename_to_final()  # confirm while recording
+        expected_final = recorder._final_path
+
+        final_path, _ = recorder.stop_recording(self.ARRIVAL + timedelta(seconds=45))
+
+        assert final_path == expected_final
+        assert expected_final is not None and expected_final.exists()
+        assert not log_file.exists()
 
     @patch("kanyo.detection.buffer_clip_manager.subprocess.Popen")
     def test_videotoolbox_encoder_command(self, mock_popen, tmp_path):

--- a/tests/test_visit_recorder.py
+++ b/tests/test_visit_recorder.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 
-from kanyo.utils.visit_recorder import VisitRecorder
+from kanyo.utils.visit_recorder import VisitRecorder, ffmpeg_log_path
 
 
 def _make_recording_recorder(
@@ -709,8 +709,9 @@ class TestStopRecordingEdgeCases:
         final_file = recorder._final_path
         assert tmp_file is not None and final_file is not None
         tmp_file.write_bytes(b"fake mp4 data")
-        # Log file at the post-rename path so the deletion branch runs
-        final_file.with_suffix(".ffmpeg.log").write_text("ffmpeg output")
+        # start_recording created the log at the real name; the deletion
+        # branch must run against that file
+        assert ffmpeg_log_path(final_file).exists()
         recorder.rename_to_final()
 
         with patch.object(Path, "unlink", side_effect=OSError("busy")):
@@ -718,6 +719,84 @@ class TestStopRecordingEdgeCases:
 
         assert path == final_file
         assert metadata["visit_file"] == str(final_file)
+        assert ffmpeg_log_path(final_file).exists()  # unlink failed, log kept
+
+
+class TestFfmpegLogPath:
+    """Tests for the shared ffmpeg log naming convention."""
+
+    def test_tmp_path_maps_to_final_log_name(self):
+        """A .mp4.tmp working path yields the log beside the final .mp4."""
+        log = ffmpeg_log_path(Path("/clips/2026-01-03/falcon_arrival.mp4.tmp"))
+        assert log == Path("/clips/2026-01-03/falcon_arrival.mp4.ffmpeg.log")
+
+    def test_final_path_maps_to_same_log_name(self):
+        """The renamed final .mp4 path yields the identical log name."""
+        log = ffmpeg_log_path(Path("/clips/2026-01-03/falcon_arrival.mp4"))
+        assert log == Path("/clips/2026-01-03/falcon_arrival.mp4.ffmpeg.log")
+
+
+class TestConfirmedStopLogCleanup:
+    """Regression tests (027): success-path cleanup targets the real log."""
+
+    @patch("subprocess.Popen")
+    def test_confirmed_stop_deletes_the_log_it_created(self, mock_popen, tmp_path):
+        """The log created at start (X.mp4.ffmpeg.log) is gone after a
+        confirmed stop.
+
+        Before 027 the cleanup computed X.ffmpeg.log from the renamed
+        final path — a name that never exists — so logs accumulated on
+        every successful recording.
+        """
+        mock_process = MagicMock()
+        mock_process.poll.return_value = None
+        mock_process.stdin = MagicMock()
+        mock_process.wait.return_value = 0
+        mock_popen.return_value = mock_process
+
+        with patch(
+            "kanyo.utils.visit_recorder.detect_hardware_encoder",
+            return_value="libx264",
+        ):
+            recorder = VisitRecorder(clips_dir=str(tmp_path))
+        recorder.start_recording(datetime(2024, 1, 15, 14, 30, 0))
+        tmp_file = recorder._visit_path
+        final_file = recorder._final_path
+        assert tmp_file is not None and final_file is not None
+        log_file = ffmpeg_log_path(tmp_file)
+        assert log_file.exists()  # start_recording really opened it
+        assert log_file == ffmpeg_log_path(final_file)  # same name both sides
+        tmp_file.write_bytes(b"fake mp4 data")
+        recorder.rename_to_final()  # confirm while recording
+
+        path, _ = recorder.stop_recording(datetime(2024, 1, 15, 15, 0, 0))
+
+        assert path == final_file
+        assert final_file.exists()
+        assert not log_file.exists()
+
+    @patch("subprocess.Popen")
+    def test_unconfirmed_stop_keeps_the_log(self, mock_popen, tmp_path):
+        """An unconfirmed (cancelled) recording keeps its log for debugging."""
+        mock_process = MagicMock()
+        mock_process.poll.return_value = None
+        mock_process.stdin = MagicMock()
+        mock_process.wait.return_value = 0
+        mock_popen.return_value = mock_process
+
+        with patch(
+            "kanyo.utils.visit_recorder.detect_hardware_encoder",
+            return_value="libx264",
+        ):
+            recorder = VisitRecorder(clips_dir=str(tmp_path))
+        recorder.start_recording(datetime(2024, 1, 15, 14, 30, 0))
+        tmp_file = recorder._visit_path
+        assert tmp_file is not None
+        log_file = ffmpeg_log_path(tmp_file)
+
+        recorder.stop_recording(datetime(2024, 1, 15, 15, 0, 0))
+
+        assert log_file.exists()
 
 
 class TestExtractClipDelegation:


### PR DESCRIPTION
## Problem

The ffmpeg stderr log is created from the `.mp4.tmp` working path — `X.mp4.ffmpeg.log` — but the success-path cleanups computed the name from the renamed final `.mp4` path via `with_suffix`, producing `X.ffmpeg.log`, a filename that never exists. Result: logs were never deleted on successful recordings and accumulate in production date dirs.

Buggy sites:
- `visit_recorder.py` confirmed-stop cleanup (~line 493)
- `arrival_clip_recorder.py` stop cleanup (~line 143)

## Fix

One naming convention, one function: `ffmpeg_log_path()` in `visit_recorder.py` resolves `X.mp4.ffmpeg.log` for both `.mp4` and `.mp4.tmp` inputs. All five creation/cleanup sites route through it (including `extract_clip_from_file`, which had a third naming variant, and the standalone arrival clip creation in `buffer_clip_manager.py`). On-disk naming unchanged.

## Tests

- Existing tests seeded logs at the wrong name (masking the bug) — corrected.
- New regression tests: confirmed stop deletes the log the recorder actually created, for both visit recordings and standalone arrival clips; unconfirmed stop keeps it; unit tests for the naming helper.
- 725 passed, coverage 100% (gate 95%), mypy clean.

## Deploy note

Production hosts have stray `*.ffmpeg.log` files accumulated from before this fix; a one-time cleanup in `/opt/services/kanyo-*/clips` is needed after deploy.