### PR TITLE
Add deno to detector images for YouTube PO-token challenge

### DIFF
--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -17,6 +17,20 @@ RUN apt-get update && apt-get install -y \
     libxrender1 \
     && rm -rf /var/lib/apt/lists/*
 
+# JavaScript runtimes for yt-dlp YouTube extraction (parity with the nvidia image):
+#   node — nsig (n-signature) challenge solver (needs v20+ for --experimental-permission)
+#   deno — PO-token / BotGuard challenge solver, required for pure-live streams.
+# Without deno, live streams fail resolution with "This video is not available".
+RUN apt-get update && apt-get install -y curl unzip \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y nodejs \
+    && curl -fsSL -o /tmp/deno.zip https://github.com/denoland/deno/releases/download/v2.9.3/deno-x86_64-unknown-linux-gnu.zip \
+    && unzip -q /tmp/deno.zip -d /usr/local/bin \
+    && rm /tmp/deno.zip \
+    && chmod 755 /usr/local/bin/deno \
+    && node --version && deno --version \
+    && rm -rf /var/lib/apt/lists/*
+
 # Set working directory
 WORKDIR /app
 

--- a/docker/Dockerfile.nvidia
+++ b/docker/Dockerfile.nvidia
@@ -30,6 +30,18 @@ RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
 
+# Install deno (pinned) — the JS runtime yt-dlp uses for the PO-token / BotGuard
+# challenge. node (above) solves the nsig challenge; deno solves the PO token,
+# which YouTube now demands for pure-live streams. Without deno, live streams
+# fail resolution with the misleading "This video is not available".
+RUN apt-get update && apt-get install -y unzip \
+    && curl -fsSL -o /tmp/deno.zip https://github.com/denoland/deno/releases/download/v2.9.3/deno-x86_64-unknown-linux-gnu.zip \
+    && unzip -q /tmp/deno.zip -d /usr/local/bin \
+    && rm /tmp/deno.zip \
+    && chmod 755 /usr/local/bin/deno \
+    && deno --version \
+    && rm -rf /var/lib/apt/lists/*
+
 # Make python3.11 the default python
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.11 1 && \
     update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1

--- a/docker/Dockerfile.vaapi
+++ b/docker/Dockerfile.vaapi
@@ -20,6 +20,20 @@ RUN apt-get update && apt-get install -y \
     vainfo \
     && rm -rf /var/lib/apt/lists/*
 
+# JavaScript runtimes for yt-dlp YouTube extraction (parity with the nvidia image):
+#   node — nsig (n-signature) challenge solver (needs v20+ for --experimental-permission)
+#   deno — PO-token / BotGuard challenge solver, required for pure-live streams.
+# Without deno, live streams fail resolution with "This video is not available".
+RUN apt-get update && apt-get install -y curl unzip \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y nodejs \
+    && curl -fsSL -o /tmp/deno.zip https://github.com/denoland/deno/releases/download/v2.9.3/deno-x86_64-unknown-linux-gnu.zip \
+    && unzip -q /tmp/deno.zip -d /usr/local/bin \
+    && rm /tmp/deno.zip \
+    && chmod 755 /usr/local/bin/deno \
+    && node --version && deno --version \
+    && rm -rf /var/lib/apt/lists/*
+
 # Set working directory
 WORKDIR /app
 


### PR DESCRIPTION
## Why

Pure-live YouTube streams now require a **PO Token** (Proof-of-Origin) generated by a BotGuard JavaScript challenge that yt-dlp runs via **deno**. The detector images shipped `node` (nsig solver) but not deno, so live streams failed with `ERROR: [youtube] <id>: This video is not available` while DVR streams kept working. Surfaced when the Harvard cam went pure-live during the v1.0.0 deploy — it could not resolve on either the old `:nvidia` or the `1.0.0-nvidia` image; NSW/UMass (DVR) were unaffected.

## What

- Install **deno 2.9.3** (pinned) in `Dockerfile.nvidia`, `Dockerfile.cpu`, `Dockerfile.vaapi`.
- Add **node 20** to cpu/vaapi for parity (previously had neither runtime).
- **No application code change** — the existing `--js-runtimes node` call resolves once deno is on PATH for the PO-token solver (node → nsig, deno → PO token).

## Verification

- Install blocks build-tested in both base images (ubuntu-22.04, debian-bookworm).
- Harvard (`glczTFRRAK4`, pure-live) resolves to a valid HLS manifest with deno present; fails without it.
- The published `1.0.1-nvidia` image will be re-tested against Harvard before the production redeploy.

Ships as **v1.0.1**.